### PR TITLE
Fix-4018: Allow multiple language parameter #4018

### DIFF
--- a/features/core-language.feature
+++ b/features/core-language.feature
@@ -23,6 +23,15 @@ Feature: Manage translation files for a WordPress install
       """
     And STDERR should be empty
 
+    When I run `wp core language install en_CA en_NZ`
+    Then the wp-content/languages/admin-en_CA.po file should exist
+    And the wp-content/languages/en_CA.po file should exist
+    And STDOUT should contain:
+      """
+      Success: Language installed.
+      """
+    And STDERR should be empty
+
     When I run `ls {SUITE_CACHE_DIR}/translation | grep core-default-`
     Then STDOUT should contain:
       """

--- a/features/core-language.feature
+++ b/features/core-language.feature
@@ -112,6 +112,12 @@ Feature: Manage translation files for a WordPress install
       """
     And STDOUT should be empty
 
+    When I try `wp core language install en_CA en_NZ --activate`
+    Then STDERR should be:
+      """
+      Error: Only a single language can be active.
+      """
+
     When I run `wp core language activate en_US`
     Then STDOUT should be:
       """

--- a/src/WP_CLI/CommandWithTranslation.php
+++ b/src/WP_CLI/CommandWithTranslation.php
@@ -136,7 +136,7 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 		$language_codes = $args;
 
 		if(  1 < count( $language_codes )  &&  in_array( true , $assoc_args , true ) ){
-			\WP_CLI::error( 'Single language can be active at a time.' );
+			\WP_CLI::error( 'Only a single language can be active.' );
 		}
 
 		$available = $this->get_installed_languages();

--- a/src/WP_CLI/CommandWithTranslation.php
+++ b/src/WP_CLI/CommandWithTranslation.php
@@ -117,7 +117,7 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 	 *
 	 * Downloads the language pack from WordPress.org.
 	 *
-	 * <language>
+	 * <language>...
 	 * : Language code to install.
 	 *
 	 * [--activate]
@@ -133,24 +133,27 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 	 */
 	public function install( $args, $assoc_args ) {
 
-		list( $language_code ) = $args;
+		$language_codes = $args;
 
 		$available = $this->get_installed_languages();
 
-		if ( in_array( $language_code, $available ) ) {
-			\WP_CLI::warning( "Language '{$language_code}' already installed." );
-		} else {
-			$response = $this->download_language_pack( $language_code );
+		foreach ($language_codes as $language_code) {
 
-			if ( is_wp_error( $response ) ) {
-				\WP_CLI::error( $response );
+			if ( in_array( $language_code, $available ) ) {
+				\WP_CLI::warning( "Language '{$language_code}' already installed." );
 			} else {
-				\WP_CLI::success( "Language installed." );
-			}
-		}
+				$response = $this->download_language_pack( $language_code );
 
-		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'activate' ) ) {
-			$this->activate( array( $language_code ), array() );
+				if ( is_wp_error( $response ) ) {
+					\WP_CLI::error( $response );
+				} else {
+					\WP_CLI::success( "Language installed." );
+				}
+			}
+
+			if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'activate' ) ) {
+				$this->activate( array( $language_code ), array() );
+			}
 		}
 
 	}

--- a/src/WP_CLI/CommandWithTranslation.php
+++ b/src/WP_CLI/CommandWithTranslation.php
@@ -135,8 +135,8 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 
 		$language_codes = $args;
 
-		if(  1 < count( $language_codes )  &&  in_array( true , $assoc_args ) ){
-			\WP_CLI::error( "Single language can be active at a time." );
+		if(  1 < count( $language_codes )  &&  in_array( true , $assoc_args , true ) ){
+			\WP_CLI::error( 'Single language can be active at a time.' );
 		}
 
 		$available = $this->get_installed_languages();

--- a/src/WP_CLI/CommandWithTranslation.php
+++ b/src/WP_CLI/CommandWithTranslation.php
@@ -135,6 +135,10 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 
 		$language_codes = $args;
 
+		if(  1 < count( $language_codes )  &&  in_array( true , $assoc_args ) ){
+			\WP_CLI::error( "Single language can be active at a time." );
+		}
+
 		$available = $this->get_installed_languages();
 
 		foreach ($language_codes as $language_code) {


### PR DESCRIPTION
Allowed passing multiple language to `wp core language install` 
Example:- `wp language core install en_US Ja`