### PR TITLE
Fix multi lang uninstall

### DIFF
--- a/features/core-language.feature
+++ b/features/core-language.feature
@@ -145,6 +145,15 @@ Feature: Manage translation files for a WordPress install
       Success: Language uninstalled.
       """
 
+    When I run `wp core language uninstall en_CA en_NZ`
+     Then the wp-content/languages/admin-en_CA.po file should not exist
+     And the wp-content/languages/en_CA.po file should not exist
+     And STDOUT should be:
+       """
+      Success: Language uninstalled.
+      Success: Language uninstalled.
+      """
+
     When I try `wp core language uninstall en_GB`
     Then STDERR should be:
       """

--- a/features/core-language.feature
+++ b/features/core-language.feature
@@ -197,9 +197,5 @@ Feature: Manage translation files for a WordPress install
     When I run `wp core language install nl_NL`
     Then STDOUT should contain:
       """
-      Using cached file '/tmp/wp-cli-home/.wp-cli/cache/translation/core-default-4.5.3-nl_NL-1468579428.zip'...
-      Unpacking the update...
-      Installing the latest version...
-      Translation updated successfully.
-      Success: Language installed.
+      Downloading translation from https://downloads.wordpress.org/translation/core/4.5.3
       """

--- a/features/core-language.feature
+++ b/features/core-language.feature
@@ -197,5 +197,9 @@ Feature: Manage translation files for a WordPress install
     When I run `wp core language install nl_NL`
     Then STDOUT should contain:
       """
-      Downloading translation from https://downloads.wordpress.org/translation/core/4.5.3
+      Using cached file '/tmp/wp-cli-home/.wp-cli/cache/translation/core-default-4.5.3-nl_NL-1468579428.zip'...
+      Unpacking the update...
+      Installing the latest version...
+      Translation updated successfully.
+      Success: Language installed.
       """

--- a/src/WP_CLI/CommandWithTranslation.php
+++ b/src/WP_CLI/CommandWithTranslation.php
@@ -399,7 +399,7 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 	/**
 	 * Uninstall a given language.
 	 *
-	 * <language>
+	 * <language>...
 	 * : Language code to uninstall.
 	 *
 	 * ## EXAMPLES
@@ -412,45 +412,49 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 	public function uninstall( $args, $assoc_args ) {
 		global $wp_filesystem;
 
-		list( $language_code ) = $args;
+		$language_codes = $args;
 
 		$available = $this->get_installed_languages();
 
-		if ( ! in_array( $language_code, $available ) ) {
-			\WP_CLI::error( "Language not installed." );
-		}
+		foreach ($language_codes as $language_code) {
 
-		$dir = 'core' === $this->obj_type ? '' : "/$this->obj_type";
-		$files = scandir( WP_LANG_DIR . $dir );
-		if ( ! $files ) {
-			\WP_CLI::error( "No files found in language directory." );
-		}
-
-		$current_locale = get_locale();
-		if ( $language_code === $current_locale ) {
-			\WP_CLI::warning( "The '{$language_code}' language is active." );
-			exit;
-		}
-
-		// As of WP 4.0, no API for deleting a language pack
-		WP_Filesystem();
-		$deleted = false;
-		foreach ( $files as $file ) {
-			if ( '.' === $file[0] || is_dir( $file ) ) {
-				continue;
+			if ( ! in_array( $language_code, $available ) ) {
+				\WP_CLI::error( "Language not installed." );
 			}
-			$extension_length = strlen( $language_code ) + 4;
-			$ending = substr( $file, -$extension_length );
-			if ( ! in_array( $file, array( $language_code . '.po', $language_code . '.mo' ) ) && ! in_array( $ending, array( '-' . $language_code . '.po', '-' . $language_code . '.mo' ) ) ) {
-				continue;
-			}
-			$deleted = $wp_filesystem->delete( WP_LANG_DIR . $dir . '/' . $file );
-		}
 
-		if ( $deleted ) {
-			\WP_CLI::success( "Language uninstalled." );
-		} else {
-			\WP_CLI::error( "Couldn't uninstall language." );
+			$dir = 'core' === $this->obj_type ? '' : "/$this->obj_type";
+			$files = scandir( WP_LANG_DIR . $dir );
+			if ( ! $files ) {
+				\WP_CLI::error( "No files found in language directory." );
+			}
+
+			$current_locale = get_locale();
+			if ( $language_code === $current_locale ) {
+				\WP_CLI::warning( "The '{$language_code}' language is active." );
+				exit;
+			}
+
+			// As of WP 4.0, no API for deleting a language pack
+			WP_Filesystem();
+			$deleted = false;
+			foreach ( $files as $file ) {
+				if ( '.' === $file[0] || is_dir( $file ) ) {
+					continue;
+				}
+				$extension_length = strlen( $language_code ) + 4;
+				$ending = substr( $file, -$extension_length );
+				if ( ! in_array( $file, array( $language_code . '.po', $language_code . '.mo' ) ) && ! in_array( $ending, array( '-' . $language_code . '.po', '-' . $language_code . '.mo' ) ) ) {
+					continue;
+				}
+				$deleted = $wp_filesystem->delete( WP_LANG_DIR . $dir . '/' . $file );
+			}
+
+			if ( $deleted ) {
+				\WP_CLI::success( "Language uninstalled." );
+			} else {
+				\WP_CLI::error( "Couldn't uninstall language." );
+			}
+
 		}
 
 	}


### PR DESCRIPTION
Allow multiple language uninstall for `wp core language uninstall` 
Ex: `wp core language uninstall en_CA en_NZ`