### PR TITLE
'core language' -> 'language core'.

### DIFF
--- a/features/language-core.feature
+++ b/features/language-core.feature
@@ -5,7 +5,7 @@ Feature: Manage translation files for a WordPress install
     Given a WP install
     And an empty cache
 
-    When I run `wp core language list --fields=language,english_name,status`
+    When I run `wp language core list --fields=language,english_name,status`
     Then STDOUT should be a table containing rows:
       | language  | english_name            | status        |
       | ar        | Arabic                  | uninstalled   |
@@ -13,8 +13,8 @@ Feature: Manage translation files for a WordPress install
       | en_US     | English (United States) | active        |
       | en_GB     | English (UK)            | uninstalled   |
 
-    When I run `wp core language install en_GB`
-    And I run `wp core language install en_AU`
+    When I run `wp language core install en_GB`
+    And I run `wp language core install en_AU`
     Then the wp-content/languages/admin-en_GB.po file should exist
     And the wp-content/languages/en_GB.po file should exist
     And STDOUT should contain:
@@ -23,7 +23,7 @@ Feature: Manage translation files for a WordPress install
       """
     And STDERR should be empty
 
-    When I run `wp core language install en_CA en_NZ`
+    When I run `wp language core install en_CA en_NZ`
     Then the wp-content/languages/admin-en_CA.po file should exist
     And the wp-content/languages/en_CA.po file should exist
     And STDOUT should contain:
@@ -42,26 +42,26 @@ Feature: Manage translation files for a WordPress install
       en_GB
       """
 
-    When I try `wp core language install en_AU`
+    When I try `wp language core install en_AU`
     Then STDERR should be:
       """
       Warning: Language 'en_AU' already installed.
       """
 
-    When I run `wp core language list --fields=language,english_name,status`
+    When I run `wp language core list --fields=language,english_name,status`
     Then STDOUT should be a table containing rows:
       | language  | english_name     | status        |
       | ar        | Arabic           | uninstalled   |
       | az        | Azerbaijani      | uninstalled   |
       | en_GB     | English (UK)     | installed     |
 
-    When I run `wp core language activate en_GB`
+    When I run `wp language core activate en_GB`
     Then STDOUT should be:
       """
       Success: Language activated.
       """
 
-    When I run `wp core language list --fields=language,english_name,update`
+    When I run `wp language core list --fields=language,english_name,update`
     Then STDOUT should be a table containing rows:
       | language  | english_name            | update        |
       | ar        | Arabic                  | none          |
@@ -70,10 +70,10 @@ Feature: Manage translation files for a WordPress install
       | en_US     | English (United States) | none          |
       | en_GB     | English (UK)            | available     |
 
-    When I run `wp core language update --dry-run`
+    When I run `wp language core update --dry-run`
     Then save STDOUT 'Available (\d+) translations updates' as {UPDATES}
 
-    When I run `wp core language update`
+    When I run `wp language core update`
     Then STDOUT should contain:
       """
       Success: Updated {UPDATES}/{UPDATES} translations.
@@ -81,20 +81,20 @@ Feature: Manage translation files for a WordPress install
     And the wp-content/languages/plugins directory should exist
     And the wp-content/languages/themes directory should exist
 
-    When I run `wp core language list --field=language --status=active`
+    When I run `wp language core list --field=language --status=active`
     Then STDOUT should be:
       """
       en_GB
       """
 
-    When I run `wp core language list --fields=language,english_name,status`
+    When I run `wp language core list --fields=language,english_name,status`
     Then STDOUT should be a table containing rows:
       | language  | english_name     | status        |
       | ar        | Arabic           | uninstalled   |
       | az        | Azerbaijani      | uninstalled   |
       | en_GB     | English (UK)     | active        |
 
-    When I run `wp core language install en_AU --activate`
+    When I run `wp language core install en_AU --activate`
     Then STDERR should contain:
       """
       Warning: Language 'en_AU' already installed.
@@ -104,7 +104,7 @@ Feature: Manage translation files for a WordPress install
       Success: Language activated.
       """
 
-    When I run `wp core language install en_AU --activate`
+    When I run `wp language core install en_AU --activate`
     Then STDERR should contain:
       """
       Warning: Language 'en_AU' already installed.
@@ -112,32 +112,32 @@ Feature: Manage translation files for a WordPress install
       """
     And STDOUT should be empty
 
-    When I try `wp core language install en_CA en_NZ --activate`
+    When I try `wp language core install en_CA en_NZ --activate`
     Then STDERR should be:
       """
       Error: Only a single language can be active.
       """
 
-    When I run `wp core language activate en_US`
+    When I run `wp language core activate en_US`
     Then STDOUT should be:
       """
       Success: Language activated.
       """
 
-    When I run `wp core language list --fields=language,english_name,status`
+    When I run `wp language core list --fields=language,english_name,status`
     Then STDOUT should be a table containing rows:
       | language  | english_name            | status        |
       | ar        | Arabic                  | uninstalled   |
       | en_US     | English (United States) | active        |
       | en_GB     | English (UK)            | installed     |
 
-    When I try `wp core language activate invalid_lang`
+    When I try `wp language core activate invalid_lang`
     Then STDERR should be:
       """
       Error: Language not installed.
       """
 
-    When I run `wp core language uninstall en_GB`
+    When I run `wp language core uninstall en_GB`
     Then the wp-content/languages/admin-en_GB.po file should not exist
     And the wp-content/languages/en_GB.po file should not exist
     And STDOUT should be:
@@ -145,7 +145,7 @@ Feature: Manage translation files for a WordPress install
       Success: Language uninstalled.
       """
 
-    When I run `wp core language uninstall en_CA en_NZ`
+    When I run `wp language core uninstall en_CA en_NZ`
      Then the wp-content/languages/admin-en_CA.po file should not exist
      And the wp-content/languages/en_CA.po file should not exist
      And STDOUT should be:
@@ -154,13 +154,13 @@ Feature: Manage translation files for a WordPress install
       Success: Language uninstalled.
       """
 
-    When I try `wp core language uninstall en_GB`
+    When I try `wp language core uninstall en_GB`
     Then STDERR should be:
       """
       Error: Language not installed.
       """
 
-    When I run `wp core language install en_GB --activate`
+    When I run `wp language core install en_GB --activate`
     Then the wp-content/languages/admin-en_GB.po file should exist
     And the wp-content/languages/en_GB.po file should exist
     And STDOUT should contain:
@@ -170,7 +170,7 @@ Feature: Manage translation files for a WordPress install
       """
     And STDERR should be empty
 
-    When I try `wp core language install invalid_lang`
+    When I try `wp language core install invalid_lang`
     Then STDERR should be:
       """
       Error: Language 'invalid_lang' not found.
@@ -180,10 +180,10 @@ Feature: Manage translation files for a WordPress install
   Scenario: Don't allow active language to be uninstalled
     Given a WP install
 
-    When I run `wp core language install en_GB --activate`
+    When I run `wp language core install en_GB --activate`
     Then STDOUT should not be empty
 
-    When I try `wp core language uninstall en_GB`
+    When I try `wp language core uninstall en_GB`
     Then STDERR should be:
       """
       Warning: The 'en_GB' language is active.
@@ -192,9 +192,10 @@ Feature: Manage translation files for a WordPress install
   @require-wp-4.0
   Scenario: Ensure correct language is installed for WP version
     Given a WP install
+	And an empty cache
     And I run `wp core download --version=4.5.3 --force`
 
-    When I run `wp core language install nl_NL`
+    When I run `wp language core install nl_NL`
     Then STDOUT should contain:
       """
       Downloading translation from https://downloads.wordpress.org/translation/core/4.5.3

--- a/src/Core_Language_Command.php
+++ b/src/Core_Language_Command.php
@@ -6,19 +6,19 @@
  * ## EXAMPLES
  *
  *     # Install language
- *     $ wp core language install nl_NL
+ *     $ wp language core install nl_NL
  *     Success: Language installed.
  *
  *     # Activate language
- *     $ wp core language activate nl_NL
+ *     $ wp language core activate nl_NL
  *     Success: Language activated.
  *
  *     # Uninstall language
- *     $ wp core language uninstall nl_NL
+ *     $ wp language core uninstall nl_NL
  *     Success: Language uninstalled.
  *
  *     # List installed languages
- *     $ wp core language list --status=installed
+ *     $ wp language core list --status=installed
  *     +----------+--------------+-------------+-----------+-----------+---------------------+
  *     | language | english_name | native_name | status    | update    | updated             |
  *     +----------+--------------+-------------+-----------+-----------+---------------------+

--- a/src/WP_CLI/CommandWithTranslation.php
+++ b/src/WP_CLI/CommandWithTranslation.php
@@ -61,7 +61,7 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 	 * ## EXAMPLES
 	 *
 	 *     # List language,english_name,status fields of available languages.
-	 *     $ wp core language list --fields=language,english_name,status
+	 *     $ wp language core list --fields=language,english_name,status
 	 *     +----------------+-------------------------+-------------+
 	 *     | language       | english_name            | status      |
 	 *     +----------------+-------------------------+-------------+
@@ -133,7 +133,7 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 	 * ## EXAMPLES
 	 *
 	 *     # Install the Japanese language.
-	 *     $ wp core language install ja
+	 *     $ wp language core install ja
 	 *     Success: Language installed.
 	 *
 	 * @subcommand install
@@ -179,7 +179,7 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     $ wp core language update
+	 *     $ wp language core update
 	 *     Updating 'Japanese' translation for Akismet 3.1.11...
 	 *     Downloading translation from https://downloads.wordpress.org/translation/plugin/akismet/3.1.11/ja.zip...
 	 *     Translation updated successfully.
@@ -270,7 +270,7 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     $ wp core language activate ja
+	 *     $ wp language core activate ja
 	 *     Success: Language activated.
 	 *
 	 * @subcommand activate
@@ -411,7 +411,7 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     $ wp core language uninstall ja
+	 *     $ wp language core uninstall ja
 	 *     Success: Language uninstalled.
 	 *
 	 * @subcommand uninstall


### PR DESCRIPTION
Issue https://github.com/wp-cli/language-command/issues/8

Changes "core language" to "language core".

Also renames `features/core-language.feature` file to `features/language-core.feature`.

Also adds `empty cache` to `features/language-core.feature:193` to make re-runnable.