### PR TITLE
Updated wp language core update --dry-run message

### DIFF
--- a/features/language-core.feature
+++ b/features/language-core.feature
@@ -73,7 +73,7 @@ Feature: Manage translation files for a WordPress install
       | en_GB     | English (UK)            | available     |
 
     When I run `wp language core update --dry-run`
-    Then save STDOUT 'Available (\d+) translations updates' as {UPDATES}
+    Then save STDOUT 'Found (\d+) translation updates that would be processed' as {UPDATES}
 
     When I run `wp language core update`
     Then STDOUT should contain:

--- a/src/WP_CLI/CommandWithTranslation.php
+++ b/src/WP_CLI/CommandWithTranslation.php
@@ -235,7 +235,7 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 
 		// Only preview which translations would be updated.
 		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run' ) ) {
-			\WP_CLI::line( sprintf( 'Available %d translations updates:', count( $updates ) ) );
+			\WP_CLI::line( sprintf( 'Found %d translation updates that would be processed:', count( $updates ) ) );
 			\WP_CLI\Utils\format_items( 'table', $updates, array( 'Type', 'Name', 'Version', 'Language' ) );
 
 			return;


### PR DESCRIPTION
Changed message to reflect using the --dry-run option 