### PR TITLE
Warn if no plugin or theme has been specified

### DIFF
--- a/features/language-plugin.feature
+++ b/features/language-plugin.feature
@@ -172,6 +172,8 @@ Feature: Manage translation files for a WordPress install
   @require-wp-4.0
   Scenario: Not providing plugin slugs should throw an error unless --all given
     Given a WP install
+    And I run `wp plugin path`
+    And save STDOUT as {PLUGIN_DIR}
 
     When I try `wp language plugin list`
     Then the return code should be 1
@@ -181,7 +183,7 @@ Feature: Manage translation files for a WordPress install
       """
     And STDOUT should be empty
 
-    Given I run `wp plugin uninstall --all`
+    Given an empty {PLUGIN_DIR} directory
     When I run `wp language plugin list --all`
     Then STDOUT should be:
       """

--- a/features/language-plugin.feature
+++ b/features/language-plugin.feature
@@ -168,3 +168,22 @@ Feature: Manage translation files for a WordPress install
       """
     And STDOUT should be empty
     And the return code should be 0
+
+  @require-wp-4.0
+  Scenario: Not providing plugin slugs should throw an error unless --all given
+    Given a WP install
+
+    When I try `wp language plugin list`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: Please specify one or more plugins, or use --all.
+      """
+    And STDOUT should be empty
+
+    Given I run `wp plugin uninstall --all`
+    When I run `wp language plugin list --all`
+    Then STDOUT should be:
+      """
+      Success: No plugins installed.
+      """

--- a/features/language-theme.feature
+++ b/features/language-theme.feature
@@ -153,3 +153,24 @@ Feature: Manage translation files for a WordPress install
       """
     And STDOUT should be empty
     And the return code should be 0
+
+  @require-wp-4.0
+  Scenario: Not providing theme slugs should throw an error unless --all given
+    Given a WP install
+    And I run `wp theme path`
+    And save STDOUT as {THEME_DIR}
+
+    When I try `wp language theme list`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: Please specify one or more themes, or use --all.
+      """
+    And STDOUT should be empty
+
+    Given an empty {THEME_DIR} directory
+    When I run `wp language theme list --all`
+    Then STDOUT should be:
+      """
+      Success: No theme installed.
+      """

--- a/features/language-theme.feature
+++ b/features/language-theme.feature
@@ -172,5 +172,5 @@ Feature: Manage translation files for a WordPress install
     When I run `wp language theme list --all`
     Then STDOUT should be:
       """
-      Success: No theme installed.
+      Success: No themes installed.
       """

--- a/src/Plugin_Language_Command.php
+++ b/src/Plugin_Language_Command.php
@@ -35,7 +35,7 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 	);
 
 	/**
-	 * Lists all available languages.
+	 * Lists all available languages for one or more plugins.
 	 *
 	 * ## OPTIONS
 	 *
@@ -97,10 +97,19 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 	public function list_( $args, $assoc_args ) {
 		$all = \WP_CLI\Utils\get_flag_value( $assoc_args, 'all', false );
 
+		if ( ! $all && empty( $args ) ) {
+			WP_CLI::error( 'Please specify one or more plugins, or use --all.' );
+		}
+
 		if ( $all ) {
 			$args = array_map( function( $file ){
 				return \WP_CLI\Utils\get_plugin_name( $file );
 			}, array_keys( $this->get_all_plugins() ) );
+
+			if ( empty( $args ) ) {
+				WP_CLI::success( 'No plugins installed.' );
+				return;
+			}
 		}
 
 		$updates        = $this->get_translation_updates();

--- a/src/Theme_Language_Command.php
+++ b/src/Theme_Language_Command.php
@@ -35,7 +35,7 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 	);
 
 	/**
-	 * Lists all available languages.
+	 * Lists all available languages for one or more themes.
 	 *
 	 * ## OPTIONS
 	 *
@@ -97,10 +97,19 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 	public function list_( $args, $assoc_args ) {
 		$all = \WP_CLI\Utils\get_flag_value( $assoc_args, 'all', false );
 
+		if ( ! $all && empty( $args ) ) {
+			WP_CLI::error( 'Please specify one or more themes, or use --all.' );
+		}
+
 		if ( $all ) {
 			$args = array_map( function( $file ){
 				return \WP_CLI\Utils\get_theme_name( $file );
 			}, array_keys( wp_get_themes() ) );
+
+			if ( empty( $args ) ) {
+				WP_CLI::success( 'No themes installed.' );
+				return;
+			}
 		}
 
 		$updates        = $this->get_translation_updates();


### PR DESCRIPTION
Somehow using `wp theme path` and then deleting that directory doesn't work... It seems to work in https://github.com/wp-cli/extension-command/pull/83/files though.

Fixes #27.