### PR TITLE
Enable updating languages for individual plugins and themes

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -26,6 +26,8 @@ labels:
     color: c5def5
   - name: command:language-core-activate
     color: c5def5
+  - name: command:language-core-is-installed
+    color: c5def5
   - name: command:language-core-install
     color: c5def5
   - name: command:language-core-list
@@ -36,6 +38,8 @@ labels:
     color: c5def5
   - name: command:language-plugin
     color: c5def5
+  - name: command:language-plugin-is-installed
+    color: c5def5
   - name: command:language-plugin-install
     color: c5def5
   - name: command:language-plugin-list
@@ -45,6 +49,8 @@ labels:
   - name: command:language-plugin-update
     color: c5def5
   - name: command:language-theme
+    color: c5def5
+  - name: command:language-theme-is-installed
     color: c5def5
   - name: command:language-theme-install
     color: c5def5

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ wp language
     $ wp language core activate nl_NL
     Success: Language activated.
 
+    # Install the Dutch language pack for Twenty Seventeen.
+    $ wp language theme install twentyseventeen nl_NL
+    Success: Language installed.
+
+    # Install the Dutch language pack for Akismet.
+    $ wp language plugin install akismet nl_NL
+    Success: Language installed.
+
 
 
 ### wp language core
@@ -213,13 +221,11 @@ wp language core uninstall <language>...
 
 ### wp language core update
 
-Updates installed languages.
+Updates installed languages for core.
 
 ~~~
 wp language core update [--dry-run]
 ~~~
-
-Updates installed languages for core.
 
 **OPTIONS**
 
@@ -264,11 +270,36 @@ wp language plugin
 
 
 
+### wp language plugin is-installed
+
+Checks if a given language is installed.
+
+~~~
+wp language plugin is-installed <plugin> <language>...
+~~~
+
+Returns exit code 0 when installed, 1 when uninstalled.
+
+**OPTIONS**
+
+	<plugin>
+		Plugin to check for.
+
+	<language>...
+		The language code to check.
+
+**EXAMPLES**
+
+    # Check whether the German language is installed for Akismet; exit status 0 if installed, otherwise 1.
+    $ wp language plugin is-installed akismet de_DE
+    $ echo $?
+    1
+
 
 
 ### wp language plugin install
 
-Installs a given language.
+Installs a given language for a plugin.
 
 ~~~
 wp language plugin install <plugin> <language>...
@@ -286,15 +317,15 @@ Downloads the language pack from WordPress.org.
 
 **EXAMPLES**
 
-    # Install the Japanese language.
-    $ wp language core install ja
+    # Install the Japanese language for Akismet.
+    $ wp language plugin install akismet ja
     Success: Language installed.
 
 
 
 ### wp language plugin list
 
-Lists all available languages.
+Lists all available languages for one or more plugins.
 
 ~~~
 wp language plugin list [<plugin>...] [--all] [--field=<field>] [--<field>=<value>] [--fields=<fields>] [--format=<format>]
@@ -359,7 +390,7 @@ These fields are optionally available:
 
 ### wp language plugin uninstall
 
-Uninstalls a given language.
+Uninstalls a given language for a plugin.
 
 ~~~
 wp language plugin uninstall <plugin> <language>...
@@ -382,22 +413,26 @@ wp language plugin uninstall <plugin> <language>...
 
 ### wp language plugin update
 
-Updates installed languages.
+Updates installed languages for one or more plugins.
 
 ~~~
-wp language plugin update [--dry-run]
+wp language plugin update [<plugin>...] [--all] [--dry-run]
 ~~~
-
-Updates installed languages for plugins.
 
 **OPTIONS**
+
+	[<plugin>...]
+		One or more plugins to update languages for.
+
+	[--all]
+		If set, languages for all plugins will be updated.
 
 	[--dry-run]
 		Preview which translations would be updated.
 
 **EXAMPLES**
 
-    $ wp language plugin update
+    $ wp language plugin update --all
     Updating 'Japanese' translation for Akismet 3.1.11...
     Downloading translation from https://downloads.wordpress.org/translation/plugin/akismet/3.1.11/ja.zip...
     Translation updated successfully.
@@ -433,11 +468,36 @@ wp language theme
 
 
 
+### wp language theme is-installed
+
+Checks if a given language is installed.
+
+~~~
+wp language theme is-installed <theme> <language>...
+~~~
+
+Returns exit code 0 when installed, 1 when uninstalled.
+
+**OPTIONS**
+
+	<theme>
+		Theme to check for.
+
+	<language>...
+		The language code to check.
+
+**EXAMPLES**
+
+    # Check whether the German language is installed for Twenty Seventeen; exit status 0 if installed, otherwise 1.
+    $ wp language theme is-installed twentyseventeen de_DE
+    $ echo $?
+    1
+
 
 
 ### wp language theme install
 
-Installs a given language.
+Installs a given language for a theme.
 
 ~~~
 wp language theme install <theme> <language>...
@@ -455,15 +515,15 @@ Downloads the language pack from WordPress.org.
 
 **EXAMPLES**
 
-    # Install the Japanese language.
-    $ wp language core install ja
+    # Install the Japanese language for Twenty Seventeen.
+    $ wp language theme install twentyseventeen ja
     Success: Language installed.
 
 
 
 ### wp language theme list
 
-Lists all available languages.
+Lists all available languages for one or more themes.
 
 ~~~
 wp language theme list [<theme>...] [--all] [--field=<field>] [--<field>=<value>] [--fields=<fields>] [--format=<format>]
@@ -528,7 +588,7 @@ These fields are optionally available:
 
 ### wp language theme uninstall
 
-Uninstalls a given language.
+Uninstalls a given language for a theme.
 
 ~~~
 wp language theme uninstall <theme> <language>...
@@ -551,22 +611,26 @@ wp language theme uninstall <theme> <language>...
 
 ### wp language theme update
 
-Updates installed languages.
+Updates installed languages for one or more themes.
 
 ~~~
-wp language theme update [--dry-run]
+wp language theme update [<plugin>...] [--all] [--dry-run]
 ~~~
-
-Updates installed languages for themes.
 
 **OPTIONS**
+
+	[<plugin>...]
+		One or more plugins to update languages for.
+
+	[--all]
+		If set, languages for all themes will be updated.
 
 	[--dry-run]
 		Preview which translations would be updated.
 
 **EXAMPLES**
 
-    $ wp language theme update
+    $ wp language theme update --all
     Updating 'Japanese' translation for Twenty Fifteen 1.5...
     Downloading translation from https://downloads.wordpress.org/translation/theme/twentyfifteen/1.5/ja.zip...
     Translation updated successfully.

--- a/features/language-core.feature
+++ b/features/language-core.feature
@@ -92,12 +92,6 @@ Feature: Manage translation files for a WordPress install
       | en_GB     | English (UK)            | none     |
       | ja        | Japanese                | none     |
 
-    When I run `wp language core update --dry-run`
-    Then STDOUT should contain:
-      """
-      Found 2 translation updates that would be processed
-      """
-
     When I run `wp language core update`
     Then STDOUT should contain:
       """

--- a/features/language-core.feature
+++ b/features/language-core.feature
@@ -93,7 +93,10 @@ Feature: Manage translation files for a WordPress install
       | ja        | Japanese                | none     |
 
     When I run `wp language core update --dry-run`
-    Then save STDOUT 'Found (\d+) translation updates that would be processed' as {UPDATES}
+    Then STDOUT should contain:
+      """
+      Found 2 translation updates that would be processed
+      """
 
     When I run `wp language core update`
     Then STDOUT should contain:

--- a/features/language-plugin.feature
+++ b/features/language-plugin.feature
@@ -215,3 +215,10 @@ Feature: Manage translation files for a WordPress install
       """
       Downloading translation from https://downloads.wordpress.org/translation/plugin/akismet/3.2/de_DE_formal.zip
       """
+
+    When I run `wp plugin install akismet --version=4.0 --force`
+    And I run `wp language plugin update akismet`
+    Then STDOUT should contain:
+      """
+      Downloading translation from https://downloads.wordpress.org/translation/plugin/akismet/4.0/de_DE_formal.zip
+      """

--- a/features/language-plugin.feature
+++ b/features/language-plugin.feature
@@ -203,3 +203,15 @@ Feature: Manage translation files for a WordPress install
       """
       Success: No plugins installed.
       """
+
+  @require-wp-4.0
+  Scenario: Ensure correct language is installed for plugin version
+    Given a WP install
+    And an empty cache
+    And I run `wp plugin install akismet --version=3.2 --force`
+
+    When I run `wp language plugin install akismet de_DE_formal`
+    Then STDOUT should contain:
+      """
+      Downloading translation from https://downloads.wordpress.org/translation/plugin/akismet/3.2/de_DE_formal.zip
+      """

--- a/features/language-plugin.feature
+++ b/features/language-plugin.feature
@@ -85,7 +85,7 @@ Feature: Manage translation files for a WordPress install
       | en_US     | English (United States) | none     |
       | en_GB     | English (UK)            | none     |
 
-    When I run `wp language plugin update`
+    When I run `wp language plugin update -all`
     Then STDOUT should contain:
       """
       Success: Translations are up to date.

--- a/features/language-plugin.feature
+++ b/features/language-plugin.feature
@@ -183,8 +183,22 @@ Feature: Manage translation files for a WordPress install
       """
     And STDOUT should be empty
 
+    When I try `wp language plugin update`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: Please specify one or more plugins, or use --all.
+      """
+    And STDOUT should be empty
+
     Given an empty {PLUGIN_DIR} directory
     When I run `wp language plugin list --all`
+    Then STDOUT should be:
+      """
+      Success: No plugins installed.
+      """
+
+    When I run `wp language plugin update --all`
     Then STDOUT should be:
       """
       Success: No plugins installed.

--- a/features/language-plugin.feature
+++ b/features/language-plugin.feature
@@ -85,7 +85,7 @@ Feature: Manage translation files for a WordPress install
       | en_US     | English (United States) | none     |
       | en_GB     | English (UK)            | none     |
 
-    When I run `wp language plugin update -all`
+    When I run `wp language plugin update --all`
     Then STDOUT should contain:
       """
       Success: Translations are up to date.

--- a/features/language-theme.feature
+++ b/features/language-theme.feature
@@ -168,8 +168,22 @@ Feature: Manage translation files for a WordPress install
       """
     And STDOUT should be empty
 
+    When I try `wp language theme update`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: Please specify one or more themes, or use --all.
+      """
+    And STDOUT should be empty
+
     Given an empty {THEME_DIR} directory
     When I run `wp language theme list --all`
+    Then STDOUT should be:
+      """
+      Success: No themes installed.
+      """
+
+    When I run `wp language theme update --all`
     Then STDOUT should be:
       """
       Success: No themes installed.

--- a/features/language-theme.feature
+++ b/features/language-theme.feature
@@ -200,3 +200,10 @@ Feature: Manage translation files for a WordPress install
       """
       Downloading translation from https://downloads.wordpress.org/translation/theme/twentyseventeen/1.0/de_DE.zip
       """
+
+    When I run `wp theme install twentyseventeen --version=1.6 --force`
+    And I run `wp language theme update twentyseventeen`
+    Then STDOUT should contain:
+      """
+      Downloading translation from https://downloads.wordpress.org/translation/theme/twentyseventeen/1.6/de_DE.zip
+      """

--- a/features/language-theme.feature
+++ b/features/language-theme.feature
@@ -84,7 +84,7 @@ Feature: Manage translation files for a WordPress install
       | en_GB     | English (UK)            | none     |
       | en_US     | English (United States) | none     |
 
-    When I run `wp language theme update`
+    When I run `wp language theme update --all`
     Then STDOUT should contain:
       """
       Success: Translations are up to date.

--- a/features/language-theme.feature
+++ b/features/language-theme.feature
@@ -188,3 +188,15 @@ Feature: Manage translation files for a WordPress install
       """
       Success: No themes installed.
       """
+
+  @require-wp-4.0
+  Scenario: Ensure correct language is installed for theme version
+    Given a WP install
+    And an empty cache
+    And I run `wp theme install twentyseventeen --version=1.0 --force`
+
+    When I run `wp language theme install twentyseventeen de_DE`
+    Then STDOUT should contain:
+      """
+      Downloading translation from https://downloads.wordpress.org/translation/theme/twentyseventeen/1.0/de_DE.zip
+      """

--- a/src/Core_Language_Command.php
+++ b/src/Core_Language_Command.php
@@ -286,7 +286,7 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 	 *     Updating 'Japanese' translation for WordPress 4.9.2...
 	 *     Downloading translation from https://downloads.wordpress.org/translation/core/4.9.2/ja.zip...
 	 *     Translation updated successfully.
-	 *     Success: Updated 1/1 translations.
+	 *     Success: Updated 1/1 translation.
 	 *
 	 * @subcommand update
 	 */

--- a/src/Core_Language_Command.php
+++ b/src/Core_Language_Command.php
@@ -273,8 +273,6 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 	}
 
 	/**
-	 * Updates installed languages.
-	 *
 	 * Updates installed languages for core.
 	 *
 	 * ## OPTIONS

--- a/src/Plugin_Language_Command.php
+++ b/src/Plugin_Language_Command.php
@@ -179,7 +179,7 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 	}
 
 	/**
-	 * Installs a given language.
+	 * Installs a given language for a plugin.
 	 *
 	 * Downloads the language pack from WordPress.org.
 	 *
@@ -222,7 +222,7 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 	}
 
 	/**
-	 * Uninstalls a given language.
+	 * Uninstalls a given language for a plugin.
 	 *
 	 * ## OPTIONS
 	 *
@@ -277,18 +277,22 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 	}
 
 	/**
-	 * Updates installed languages.
-	 *
-	 * Updates installed languages for plugins.
+	 * Updates installed languages for one or more plugins.
 	 *
 	 * ## OPTIONS
+	 *
+	 * [<plugin>...]
+	 * : One or more plugins to update languages for.
+	 *
+	 * [--all]
+	 * : If set, languages for all plugins will be updated.
 	 *
 	 * [--dry-run]
 	 * : Preview which translations would be updated.
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     $ wp language plugin update
+	 *     $ wp language plugin update --all
 	 *     Updating 'Japanese' translation for Akismet 3.1.11...
 	 *     Downloading translation from https://downloads.wordpress.org/translation/plugin/akismet/3.1.11/ja.zip...
 	 *     Translation updated successfully.
@@ -297,6 +301,23 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 	 * @subcommand update
 	 */
 	public function update( $args, $assoc_args ) {
+		$all = \WP_CLI\Utils\get_flag_value( $assoc_args, 'all', false );
+
+		if ( ! $all && empty( $args ) ) {
+			WP_CLI::error( 'Please specify one or more plugins, or use --all.' );
+		}
+
+		if ( $all ) {
+			$args = array_map( function ( $file ) {
+				return \WP_CLI\Utils\get_plugin_name( $file );
+			}, array_keys( $this->get_all_plugins() ) );
+			if ( empty( $args ) ) {
+				WP_CLI::success( 'No plugins installed.' );
+
+				return;
+			}
+		}
+
 		parent::update( $args, $assoc_args );
 	}
 

--- a/src/Plugin_Language_Command.php
+++ b/src/Plugin_Language_Command.php
@@ -305,7 +305,7 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 	 *     Updating 'Japanese' translation for Akismet 3.1.11...
 	 *     Downloading translation from https://downloads.wordpress.org/translation/plugin/akismet/3.1.11/ja.zip...
 	 *     Translation updated successfully.
-	 *     Success: Updated 1/1 translations.
+	 *     Success: Updated 1/1 translation.
 	 *
 	 * @subcommand update
 	 */

--- a/src/Theme_Language_Command.php
+++ b/src/Theme_Language_Command.php
@@ -305,7 +305,7 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 	 *     Updating 'Japanese' translation for Twenty Fifteen 1.5...
 	 *     Downloading translation from https://downloads.wordpress.org/translation/theme/twentyfifteen/1.5/ja.zip...
 	 *     Translation updated successfully.
-	 *     Success: Updated 1/1 translations.
+	 *     Success: Updated 1/1 translation.
 	 *
 	 * @subcommand update
 	 */

--- a/src/Theme_Language_Command.php
+++ b/src/Theme_Language_Command.php
@@ -179,7 +179,7 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 	}
 
 	/**
-	 * Installs a given language.
+	 * Installs a given language for a theme.
 	 *
 	 * Downloads the language pack from WordPress.org.
 	 *
@@ -222,7 +222,7 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 	}
 
 	/**
-	 * Uninstalls a given language.
+	 * Uninstalls a given language for a theme.
 	 *
 	 * ## OPTIONS
 	 *
@@ -277,18 +277,22 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 	}
 
 	/**
-	 * Updates installed languages.
-	 *
-	 * Updates installed languages for themes.
+	 * Updates installed languages for one or more themes.
 	 *
 	 * ## OPTIONS
+	 *
+	 * [<plugin>...]
+	 * : One or more plugins to update languages for.
+	 *
+	 * [--all]
+	 * : If set, languages for all themes will be updated.
 	 *
 	 * [--dry-run]
 	 * : Preview which translations would be updated.
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     $ wp language theme update
+	 *     $ wp language theme update --all
 	 *     Updating 'Japanese' translation for Twenty Fifteen 1.5...
 	 *     Downloading translation from https://downloads.wordpress.org/translation/theme/twentyfifteen/1.5/ja.zip...
 	 *     Translation updated successfully.
@@ -297,6 +301,23 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 	 * @subcommand update
 	 */
 	public function update( $args, $assoc_args ) {
+		$all = \WP_CLI\Utils\get_flag_value( $assoc_args, 'all', false );
+
+		if ( ! $all && empty( $args ) ) {
+			WP_CLI::error( 'Please specify one or more themes, or use --all.' );
+		}
+
+		if ( $all ) {
+			$args = array_map( function ( $file ) {
+				return \WP_CLI\Utils\get_theme_name( $file );
+			}, array_keys( wp_get_themes() ) );
+			if ( empty( $args ) ) {
+				WP_CLI::success( 'No themes installed.' );
+
+				return;
+			}
+		}
+
 		parent::update( $args, $assoc_args );
 	}
 }

--- a/src/WP_CLI/CommandWithTranslation.php
+++ b/src/WP_CLI/CommandWithTranslation.php
@@ -35,9 +35,16 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 		}
 
 		// Only preview which translations would be updated.
-		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run' ) ) {
-			\WP_CLI::line( sprintf( 'Found %d translation updates that would be processed:', count( $updates ) ) );
-			\WP_CLI\Utils\format_items( 'table', $updates, array( 'Type', 'Name', 'Version', 'Language' ) );
+		if ( Utils\get_flag_value( $assoc_args, 'dry-run' ) ) {
+			WP_CLI::line( sprintf( 'Found %d translation updates that would be processed:', count( $updates ) ) );
+
+			$fields = array( 'type', 'slug', 'language', 'version' );
+
+			if ( 'core' === $this->obj_type ) {
+				$fields = array( 'type', 'language', 'version' );
+			}
+
+			WP_CLI\Utils\format_items( 'table', $updates, $fields );
 
 			return;
 		}

--- a/src/WP_CLI/CommandWithTranslation.php
+++ b/src/WP_CLI/CommandWithTranslation.php
@@ -239,7 +239,7 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 	/**
 	 * Return a list of all languages
 	 *
-	 * @param string $slug Optional. Plugin or theme slug. Not used fore core.
+	 * @param string $slug Optional. Plugin or theme slug. Not used for core.
 	 *
 	 * @return array
 	 */

--- a/src/WP_CLI/CommandWithTranslation.php
+++ b/src/WP_CLI/CommandWithTranslation.php
@@ -5,8 +5,6 @@ namespace WP_CLI;
 use WP_CLI;
 use WP_CLI_Command;
 
-use function WP_CLI\Utils\pluralize;
-
 /**
  * Base class for WP-CLI commands that deal with translations
  *
@@ -108,7 +106,7 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 				sprintf(
 					'Found %d translation %s that would be processed:',
 					$update_count,
-					pluralize( 'update', $update_count )
+					WP_CLI\Utils\pluralize( 'update', $update_count )
 				)
 			);
 
@@ -119,7 +117,7 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 
 		$num_updated = count( array_filter( $results ) );
 
-		$line = sprintf( "Updated $num_updated/$num_to_update %s.", pluralize( 'translation', $num_updated ) );
+		$line = sprintf( "Updated $num_updated/$num_to_update %s.", WP_CLI\Utils\pluralize( 'translation', $num_updated ) );
 
 		if ( $num_to_update === $num_updated ) {
 			WP_CLI::success( $line );

--- a/src/WP_CLI/CommandWithTranslation.php
+++ b/src/WP_CLI/CommandWithTranslation.php
@@ -34,21 +34,6 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 			return;
 		}
 
-		// Only preview which translations would be updated.
-		if ( Utils\get_flag_value( $assoc_args, 'dry-run' ) ) {
-			WP_CLI::line( sprintf( 'Found %d translation updates that would be processed:', count( $updates ) ) );
-
-			$fields = array( 'type', 'slug', 'language', 'version' );
-
-			if ( 'core' === $this->obj_type ) {
-				$fields = array( 'type', 'language', 'version' );
-			}
-
-			WP_CLI\Utils\format_items( 'table', $updates, $fields );
-
-			return;
-		}
-
 		if ( empty( $args ) ) {
 			$args = array( null ); // Used for core.
 		}
@@ -106,6 +91,14 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 
 				$results[] = $result;
 			}
+		}
+
+		// Only preview which translations would be updated.
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run' ) ) {
+			\WP_CLI::line( sprintf( 'Found %d translation updates that would be processed:', count( $updates ) ) );
+			\WP_CLI\Utils\format_items( 'table', $updates, array( 'Type', 'Name', 'Version', 'Language' ) );
+
+			return;
 		}
 
 		$num_updated = count( array_filter( $results ) );

--- a/src/WP_CLI/CommandWithTranslation.php
+++ b/src/WP_CLI/CommandWithTranslation.php
@@ -114,9 +114,9 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 			WP_CLI::success( $line );
 		} else if ( $num_updated > 0 ) {
 			WP_CLI::warning( $line );
+		} else {
+			WP_CLI::error( $line );
 		}
-
-		WP_CLI::error( $line );
 	}
 
 	/**

--- a/src/WP_CLI/CommandWithTranslation.php
+++ b/src/WP_CLI/CommandWithTranslation.php
@@ -5,6 +5,8 @@ namespace WP_CLI;
 use WP_CLI;
 use WP_CLI_Command;
 
+use function WP_CLI\Utils\pluralize;
+
 /**
  * Base class for WP-CLI commands that deal with translations
  *
@@ -100,7 +102,16 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 
 		// Only preview which translations would be updated.
 		if ( Utils\get_flag_value( $assoc_args, 'dry-run' ) ) {
-			WP_CLI::line( sprintf( 'Found %d translation updates that would be processed:', count( $updates ) ) );
+			$update_count = count( $updates );
+
+			WP_CLI::line(
+				sprintf(
+					'Found %d translation %s that would be processed:',
+					$update_count,
+					pluralize( 'update', $update_count )
+				)
+			);
+
 			Utils\format_items( 'table', $updates, array( 'Type', 'Name', 'Version', 'Language' ) );
 
 			return;
@@ -108,7 +119,7 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 
 		$num_updated = count( array_filter( $results ) );
 
-		$line = "Updated $num_updated/$num_to_update translations.";
+		$line = sprintf( "Updated $num_updated/$num_to_update %s.", pluralize( 'translation', $num_updated ) );
 
 		if ( $num_to_update === $num_updated ) {
 			WP_CLI::success( $line );

--- a/src/WP_CLI/CommandWithTranslation.php
+++ b/src/WP_CLI/CommandWithTranslation.php
@@ -50,6 +50,8 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 
 			// Formats the updates list.
 			foreach ( $updates as $update ) {
+				$name = 'WordPress'; // Core.
+
 				if ( 'plugin' === $update->type ) {
 					$plugins	 = get_plugins( '/' . $update->slug );
 					$plugin_data = array_shift( $plugins );
@@ -57,8 +59,6 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 				} elseif ( 'theme' === $update->type ) {
 					$theme_data	 = wp_get_theme( $update->slug );
 					$name		 = $theme_data['Name'];
-				} else { // Core
-					$name = 'WordPress';
 				}
 
 				// Gets the translation data.
@@ -86,20 +86,22 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 
 			$num_to_update += count( $available_updates );
 
-			// Update translations.
-			foreach ( $available_updates as $update ) {
-				WP_CLI::line( "Updating '{$update->Language}' translation for {$update->Name} {$update->Version}..." );
+			if ( ! Utils\get_flag_value( $assoc_args, 'dry-run' ) ) {
+				// Update translations.
+				foreach ( $available_updates as $update ) {
+					WP_CLI::line( "Updating '{$update->Language}' translation for {$update->Name} {$update->Version}..." );
 
-				$result = Utils\get_upgrader( $upgrader )->upgrade( $update );
+					$result = Utils\get_upgrader( $upgrader )->upgrade( $update );
 
-				$results[] = $result;
+					$results[] = $result;
+				}
 			}
 		}
 
 		// Only preview which translations would be updated.
-		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run' ) ) {
-			\WP_CLI::line( sprintf( 'Found %d translation updates that would be processed:', count( $updates ) ) );
-			\WP_CLI\Utils\format_items( 'table', $updates, array( 'Type', 'Name', 'Version', 'Language' ) );
+		if ( Utils\get_flag_value( $assoc_args, 'dry-run' ) ) {
+			WP_CLI::line( sprintf( 'Found %d translation updates that would be processed:', count( $updates ) ) );
+			Utils\format_items( 'table', $updates, array( 'Type', 'Name', 'Version', 'Language' ) );
 
 			return;
 		}
@@ -112,9 +114,9 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 			WP_CLI::success( $line );
 		} else if ( $num_updated > 0 ) {
 			WP_CLI::warning( $line );
-		} else {
-			WP_CLI::error( $line );
 		}
+
+		WP_CLI::error( $line );
 	}
 
 	/**

--- a/src/WP_CLI/CommandWithTranslation.php
+++ b/src/WP_CLI/CommandWithTranslation.php
@@ -67,10 +67,13 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 				) );
 				$translation = (object) reset( $translation );
 
-				$update->Type		 = ucfirst( $update->type );
-				$update->Name		 = $name;
-				$update->Version	 = $update->version;
-				$update->Language	 = $translation->english_name;
+				$update->Type    = ucfirst( $update->type );
+				$update->Name    = $name;
+				$update->Version = $update->version;
+
+				if ( isset( $translation->english_name ) ) {
+					$update->Language = $translation->english_name;
+				}
 
 				if ( ! isset( $updates_per_type[ $update->type ] ) ) {
 					$updates_per_type[ $update->type ] = array();


### PR DESCRIPTION
Fixes #39.

This means that for updating all translations on a site, one has to run the following commands

```bash
wp language core update
wp language plugin update --all
wp language theme update --all
```

----

Additional thoughts:

`\WP_CLI\CommandWithTranslation::get_translation_updates()` uses the list of available locales for the the plugin and theme update checks to tell WordPress.org which locales are already installed.

An example scenario can be that `de_DE` is installed for core, but only `ja` and `en_GB` for `akismet`. The update command (and perhaps even the list command?) might show false information in that case, indicating that no update for `ja` and `en_GB` is available, because only `de_DE` is checked. I haven't properly tested that though.

To fix this, instead of passing all installed locales we could try passing all possible locales that can be installed (using `\WP_CLI\CommandWithTranslation::get_all_languages()`).

Background: `\WP_CLI\CommandWithTranslation::update()` calls `\WP_CLI\CommandWithTranslation::get_translation_updates()` which in turn calls `\WP_CLI\CommandWithTranslation::get_installed_languages()`. It does so without passing the plugin/theme slug (relying on the default instead, which is `default`).

This is something we might want to explore in a separate issue.