### PR TITLE
Make sure upgrader strings are always in English

### DIFF
--- a/features/language-core.feature
+++ b/features/language-core.feature
@@ -301,3 +301,33 @@ Feature: Manage translation files for a WordPress install
       """
       Downloading translation from https://downloads.wordpress.org/translation/core/4.5.3
       """
+
+  @require-wp-4.0
+  Scenario: Ensure upgrader output is in English
+    Given a WP install
+    And an empty cache
+    And I run `wp core download --version=4.7.1 --force`
+
+    When I run `wp language core install de_DE --activate`
+    Then STDOUT should contain:
+      """
+      Downloading translation from https://downloads.wordpress.org/translation/core/4.7.1/de_DE.zip
+      """
+
+    When I run `wp language core install nl_NL`
+    Then STDOUT should contain:
+      """
+      Downloading translation from https://downloads.wordpress.org/translation/core/4.7.1/nl_NL.zip
+      """
+    And STDOUT should contain:
+      """
+      Installing the latest version
+      """
+    And STDOUT should not contain:
+      """
+      Lädt Übersetzung von https://downloads.wordpress.org/translation/core/4.7.1./nl_NL.zip
+      """
+    And STDOUT should not contain:
+      """
+      Die aktuelle Version wird installiert
+      """

--- a/src/WP_CLI/LanguagePackUpgrader.php
+++ b/src/WP_CLI/LanguagePackUpgrader.php
@@ -10,11 +10,38 @@ use WP_CLI;
  * @package wp-cli
  */
 class LanguagePackUpgrader extends \Language_Pack_Upgrader {
+	/**
+	 * Initialize the upgrade strings.
+	 *
+	 * Makes sure that the strings are always in English.
+	 */
+	public function upgrade_strings() {
+		$switched_locale = function_exists( 'switch_to_locale' ) && switch_to_locale( 'en_US' );
+
+		parent::upgrade_strings();
+
+		if ( $switched_locale ) {
+			restore_previous_locale();
+		}
+	}
+
+	/**
+	 * Initialize the generic strings.
+	 *
+	 * Makes sure that the strings are always in English.
+	 */
+	public function generic_strings() {
+		$switched_locale = function_exists( 'switch_to_locale' ) && switch_to_locale( 'en_US' );
+
+		parent::generic_strings();
+
+		if ( $switched_locale ) {
+			restore_previous_locale();
+		}
+	}
 
 	/**
 	 * Caches the download, and uses cached if available.
-	 *
-	 * @access public
 	 *
 	 * @param string $package The URI of the package. If this is the full path to an
 	 *                        existing local file, it will be returned untouched.


### PR DESCRIPTION
Instead of manually copying all possible strings to the upgrader class I opted to use `switch_to_locale()`.

The advantage of using `switch_to_locale()` is that we're always using the correct strings from WordPress core, even if they change between releases.

The disadvantage is that this only works for WordPress 4.7+ and that — given there are string changes in core — the upgrader messages might differ depending on the WP version.

Fixes #52.