### PR TITLE
[WIP] Make use of report_batch_operation_results() for install commands

### DIFF
--- a/src/Plugin_Language_Command.php
+++ b/src/Plugin_Language_Command.php
@@ -206,23 +206,29 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 	public function install( $args, $assoc_args ) {
 		$plugin         = array_shift( $args );
 		$language_codes = (array) $args;
+		$count          = count( $language_codes );
 
 		$available = $this->get_installed_languages( $plugin );
 
 		foreach ( $language_codes as $language_code ) {
 
 			if ( in_array( $language_code, $available, true ) ) {
-				\WP_CLI::warning( "Language '{$language_code}' already installed." );
+				\WP_CLI::log( "Language '{$language_code}' already installed." );
+				$skips++;
 			} else {
 				$response = $this->download_language_pack( $language_code, $plugin );
 
 				if ( is_wp_error( $response ) ) {
-					\WP_CLI::error( $response );
+					WP_CLI::warning( $response );
+					$errors++;
 				} else {
-					\WP_CLI::success( 'Language installed.' );
+					\WP_CLI::log( 'Language installed.' );
+					$successes++;
 				}
 			}
 		}
+
+		\WP_CLI\Utils\report_batch_operation_results( 'language', 'install', $count, $successes, $errors, $skips );
 	}
 
 	/**

--- a/src/Theme_Language_Command.php
+++ b/src/Theme_Language_Command.php
@@ -208,23 +208,30 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 	public function install( $args, $assoc_args ) {
 		$theme          = array_shift( $args );
 		$language_codes = (array) $args;
+		$count          = count( $language_codes );
 
 		$available = $this->get_installed_languages( $theme );
 
+		$successes = $errors = $skips = 0;
 		foreach ( $language_codes as $language_code ) {
 
 			if ( in_array( $language_code, $available, true ) ) {
-				\WP_CLI::warning( "Language '{$language_code}' already installed." );
+				\WP_CLI::log( "Language '{$language_code}' already installed." );
+				$skips++;
 			} else {
 				$response = $this->download_language_pack( $language_code, $theme );
 
 				if ( is_wp_error( $response ) ) {
-					\WP_CLI::error( $response );
+					WP_CLI::warning( $response );
+					$errors++;
 				} else {
-					\WP_CLI::success( 'Language installed.' );
+					\WP_CLI::log( 'Language installed.' );
+					$successes++;
 				}
 			}
 		}
+
+		\WP_CLI\Utils\report_batch_operation_results( 'language', 'install', $count, $successes, $errors, $skips );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #61.

Example output:

```
➜  ~ wpd language theme install twentytwelve fo_Ba de_DE
Warning: Language 'fo_Ba' not found.
Warning: Could not create directory. "/srv/www/wordpress-develop/shared/public_html/develop-languages/"
Error: No languages installed (2 failed).

➜ ~ wpd language theme install twentytwelve fo_Ba de_DE
Warning: Language 'fo_Ba' not found.
Language 'de_DE' already installed.
Error: No languages installed (1 failed, 1 skipped).

➜ ~ wpd language theme install twentytwelve fo_Ba th
Warning: Language 'fo_Ba' not found.
Downloading translation from https://downloads.wordpress.org/translation/theme/twentytwelve/2.5/th.zip...
Unpacking the update...
Installing the latest version...
Translation updated successfully.
Language installed.
Error: Only installed 1 of 2 languages (1 failed).

➜ ~ wpd language theme install twentytwelve fo_Ba
Warning: Language 'fo_Ba' not found.
Error: No languages installed (1 failed).

➜ ~ wpd language theme install twentytwelve th
Language 'th' already installed.
Success: Installed 0 of 1 languages (1 skipped).

➜ ~ wpd language theme install twentytwelve es_MX
Downloading translation from https://downloads.wordpress.org/translation/theme/twentytwelve/2.5/es_MX.zip...
Unpacking the update...
Installing the latest version...
Translation updated successfully.
Language installed.
Success: Installed 1 of 1 languages.
```