### PR TITLE
Move PHP 5.4 tests from `WP_VERSION` `latest` to `5.1`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,4 +71,4 @@ jobs:
     - stage: test
       php: 5.4
       dist: precise
-      env: WP_VERSION=latest
+      env: WP_VERSION=5.1


### PR DESCRIPTION
Related wp-cli/wp-cli#5127