### PR TITLE
PHPCS: fix up the code base [1] - various small fixes

### DIFF
--- a/language-command.php
+++ b/language-command.php
@@ -13,7 +13,7 @@ if ( file_exists( $autoload ) ) {
 WP_CLI::add_command( 'language core', 'Core_Language_Command', array(
 	'before_invoke' => function() {
 		if ( \WP_CLI\Utils\wp_version_compare( '4.0', '<' ) ) {
-			WP_CLI::error( "Requires WordPress 4.0 or greater." );
+			WP_CLI::error( 'Requires WordPress 4.0 or greater.' );
 		}
 	})
 );
@@ -21,7 +21,7 @@ WP_CLI::add_command( 'language core', 'Core_Language_Command', array(
 WP_CLI::add_command( 'language plugin', 'Plugin_Language_Command', array(
 		'before_invoke' => function() {
 			if ( \WP_CLI\Utils\wp_version_compare( '4.0', '<' ) ) {
-				WP_CLI::error( "Requires WordPress 4.0 or greater." );
+				WP_CLI::error( 'Requires WordPress 4.0 or greater.' );
 			}
 		})
 );
@@ -29,7 +29,7 @@ WP_CLI::add_command( 'language plugin', 'Plugin_Language_Command', array(
 WP_CLI::add_command( 'language theme', 'Theme_Language_Command', array(
 		'before_invoke' => function() {
 			if ( \WP_CLI\Utils\wp_version_compare( '4.0', '<' ) ) {
-				WP_CLI::error( "Requires WordPress 4.0 or greater." );
+				WP_CLI::error( 'Requires WordPress 4.0 or greater.' );
 			}
 		})
 );

--- a/src/Core_Language_Command.php
+++ b/src/Core_Language_Command.php
@@ -110,8 +110,8 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 			return $translation;
 		}, $translations );
 
-		foreach( $translations as $key => $translation ) {
-			foreach( array_keys( $translation ) as $field ) {
+		foreach ( $translations as $key => $translation ) {
+			foreach ( array_keys( $translation ) as $field ) {
 				if ( isset( $assoc_args[ $field ] ) && $assoc_args[ $field ] !== $translation[ $field ] ) {
 					unset( $translations[ $key ] );
 				}
@@ -143,7 +143,7 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 	 */
 	public function is_installed( $args, $assoc_args = array() ) {
 		list( $language_code ) = $args;
-		$available = $this->get_installed_languages();
+		$available             = $this->get_installed_languages();
 		if ( in_array( $language_code, $available, true ) ) {
 			\WP_CLI::halt( 0 );
 		} else {
@@ -187,7 +187,9 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 
 		$available = $this->get_installed_languages();
 
-		$successes = $errors = $skips = 0;
+		$successes = 0;
+		$errors    = 0;
+		$skips     = 0;
 		foreach ( $language_codes as $language_code ) {
 
 			if ( in_array( $language_code, $available, true ) ) {
@@ -243,13 +245,13 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 
 		$available = $this->get_installed_languages();
 
-		foreach ($language_codes as $language_code) {
+		foreach ( $language_codes as $language_code ) {
 
 			if ( ! in_array( $language_code, $available, true ) ) {
 				WP_CLI::error( 'Language not installed.' );
 			}
 
-			$dir = 'core' === $this->obj_type ? '' : "/$this->obj_type";
+			$dir   = 'core' === $this->obj_type ? '' : "/$this->obj_type";
 			$files = scandir( WP_LANG_DIR . $dir );
 			if ( ! $files ) {
 				WP_CLI::error( 'No files found in language directory.' );
@@ -269,12 +271,12 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 					continue;
 				}
 				$extension_length = strlen( $language_code ) + 4;
-				$ending = substr( $file, -$extension_length );
+				$ending           = substr( $file, -$extension_length );
 				if ( ! in_array( $file, array( $language_code . '.po', $language_code . '.mo' ), true ) && ! in_array( $ending, array( '-' . $language_code . '.po', '-' . $language_code . '.mo' ), true ) ) {
 					continue;
 				}
 
-				/* @var WP_Filesystem_Base $wp_filesystem */
+				/** @var WP_Filesystem_Base $wp_filesystem */
 				$deleted = $wp_filesystem->delete( WP_LANG_DIR . $dir . '/' . $file );
 			}
 
@@ -339,11 +341,11 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 			WP_CLI::error( 'Language not installed.' );
 		}
 
-		if ( $language_code === 'en_US' ) {
+		if ( 'en_US' === $language_code ) {
 			$language_code = '';
 		}
 
-		if ( $language_code === get_locale() ) {
+		if ( get_locale() === $language_code ) {
 			WP_CLI::warning( "Language '{$language_code}' already active." );
 
 			return;

--- a/src/Plugin_Language_Command.php
+++ b/src/Plugin_Language_Command.php
@@ -131,7 +131,7 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 				$translation['update'] = $update ? 'available' : 'none';
 
 				// Support features like --status=active.
-				foreach( array_keys( $translation ) as $field ) {
+				foreach ( array_keys( $translation ) as $field ) {
 					if ( isset( $assoc_args[ $field ] ) && $assoc_args[ $field ] !== $translation[ $field ] ) {
 						continue 2;
 					}
@@ -249,7 +249,9 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 
 		$available = $this->get_installed_languages( $plugin );
 
-		$successes = $errors = $skips = 0;
+		$successes = 0;
+		$errors    = 0;
+		$skips     = 0;
 		foreach ( $language_codes as $language_code ) {
 
 			if ( in_array( $language_code, $available, true ) ) {
@@ -293,7 +295,7 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 		}
 
 		if ( in_array( $assoc_args['format'], array( 'json', 'csv' ) ) ) {
-			$logger = new \WP_CLI\Loggers\Quiet;
+			$logger = new \WP_CLI\Loggers\Quiet();
 			\WP_CLI::set_logger( $logger );
 		}
 
@@ -306,7 +308,9 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 
 		$results = array();
 
-		$successes = $errors = $skips = 0;
+		$successes = 0;
+		$errors    = 0;
+		$skips     = 0;
 		foreach ( $plugins as $plugin_path => $plugin_details ) {
 			$plugin_name = \WP_CLI\Utils\get_plugin_name( $plugin_path );
 
@@ -373,7 +377,7 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 	 * @subcommand uninstall
 	 */
 	public function uninstall( $args, $assoc_args ) {
-		/* @var WP_Filesystem_Base $wp_filesystem */
+		/** @var WP_Filesystem_Base $wp_filesystem */
 		global $wp_filesystem;
 
 		$plugin         = array_shift( $args );

--- a/src/Site_Switch_Language_Command.php
+++ b/src/Site_Switch_Language_Command.php
@@ -27,11 +27,11 @@ class Site_Switch_Language_Command extends WP_CLI\CommandWithTranslation {
 			WP_CLI::error( 'Language not installed.' );
 		}
 
-		if ( $language_code === 'en_US' ) {
+		if ( 'en_US' === $language_code ) {
 			$language_code = '';
 		}
 
-		if ( $language_code === get_locale() ) {
+		if ( get_locale() === $language_code ) {
 			WP_CLI::warning( "Language '{$language_code}' already active." );
 
 			return;

--- a/src/Theme_Language_Command.php
+++ b/src/Theme_Language_Command.php
@@ -117,7 +117,7 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 			$available_translations = $this->get_all_languages( $theme );
 
 			foreach ( $available_translations as $translation ) {
-				$translation['theme'] = $theme;
+				$translation['theme']  = $theme;
 				$translation['status'] = in_array( $translation['language'], $installed_translations, true ) ? 'installed' : 'uninstalled';
 
 				if ( $current_locale === $translation['language'] ) {
@@ -133,7 +133,7 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 				$translation['update'] = $update ? 'available' : 'none';
 
 				// Support features like --status=active.
-				foreach( array_keys( $translation ) as $field ) {
+				foreach ( array_keys( $translation ) as $field ) {
 					if ( isset( $assoc_args[ $field ] ) && $assoc_args[ $field ] !== $translation[ $field ] ) {
 						continue 2;
 					}
@@ -251,7 +251,9 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 
 		$available = $this->get_installed_languages( $theme );
 
-		$successes = $errors = $skips = 0;
+		$successes = 0;
+		$errors    = 0;
+		$skips     = 0;
 		foreach ( $language_codes as $language_code ) {
 
 			if ( in_array( $language_code, $available, true ) ) {
@@ -295,7 +297,7 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 		}
 
 		if ( in_array( $assoc_args['format'], array( 'json', 'csv' ) ) ) {
-			$logger = new \WP_CLI\Loggers\Quiet;
+			$logger = new \WP_CLI\Loggers\Quiet();
 			\WP_CLI::set_logger( $logger );
 		}
 
@@ -308,7 +310,9 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 
 		$results = array();
 
-		$successes = $errors = $skips = 0;
+		$successes = 0;
+		$errors    = 0;
+		$skips     = 0;
 		foreach ( $themes as $theme_path => $theme_details ) {
 			$theme_name = \WP_CLI\Utils\get_theme_name( $theme_path );
 
@@ -375,7 +379,7 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 	 * @subcommand uninstall
 	 */
 	public function uninstall( $args, $assoc_args ) {
-		/* @var WP_Filesystem_Base $wp_filesystem */
+		/** @var WP_Filesystem_Base $wp_filesystem */
 		global $wp_filesystem;
 
 		$theme          = array_shift( $args );

--- a/src/WP_CLI/CommandWithTranslation.php
+++ b/src/WP_CLI/CommandWithTranslation.php
@@ -38,8 +38,8 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 			$args = array( null ); // Used for core.
 		}
 
-		$upgrader = 'WP_CLI\\LanguagePackUpgrader';
-		$results = array();
+		$upgrader      = 'WP_CLI\\LanguagePackUpgrader';
+		$results       = array();
 		$num_to_update = 0;
 
 		foreach ( $args as $slug ) {
@@ -57,12 +57,12 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 				$name = 'WordPress'; // Core.
 
 				if ( 'plugin' === $update->type ) {
-					$plugins	 = get_plugins( '/' . $update->slug );
+					$plugins     = get_plugins( '/' . $update->slug );
 					$plugin_data = array_shift( $plugins );
-					$name		 = $plugin_data['Name'];
+					$name        = $plugin_data['Name'];
 				} elseif ( 'theme' === $update->type ) {
-					$theme_data	 = wp_get_theme( $update->slug );
-					$name		 = $theme_data['Name'];
+					$theme_data = wp_get_theme( $update->slug );
+					$name       = $theme_data['Name'];
 				}
 
 				// Gets the translation data.
@@ -129,7 +129,7 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 
 		if ( $num_to_update === $num_updated ) {
 			WP_CLI::success( $line );
-		} else if ( $num_updated > 0 ) {
+		} elseif ( $num_updated > 0 ) {
 			WP_CLI::warning( $line );
 		} else {
 			WP_CLI::error( $line );
@@ -150,7 +150,7 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 			return $available;
 		};
 
-		switch( $this->obj_type ) {
+		switch ( $this->obj_type ) {
 			case 'plugins':
 				add_filter( 'plugins_update_check_locales', $func );
 
@@ -207,7 +207,7 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 	 * @return string|\WP_Error Returns the language code if successfully downloaded, or a WP_Error object on failure.
 	 */
 	protected function download_language_pack( $download, $slug = null ) {
-		$translations = $this->get_all_languages( $slug );
+		$translations        = $this->get_all_languages( $slug );
 		$translation_to_load = null;
 
 		foreach ( $translations as $translation ) {
@@ -230,7 +230,7 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 		}
 
 		$upgrader = 'WP_CLI\\LanguagePackUpgrader';
-		$result = Utils\get_upgrader( $upgrader )->upgrade( $translation, array( 'clear_update_cache' => false ) );
+		$result   = Utils\get_upgrader( $upgrader )->upgrade( $translation, array( 'clear_update_cache' => false ) );
 
 		if ( is_wp_error( $result ) ) {
 			return $result;
@@ -251,8 +251,8 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 	 * @return array
 	 */
 	protected function get_installed_languages( $slug = 'default' ) {
-		$available = wp_get_installed_translations( $this->obj_type );
-		$available = ! empty( $available[ $slug ] ) ? array_keys( $available[ $slug ] ) : array();
+		$available   = wp_get_installed_translations( $this->obj_type );
+		$available   = ! empty( $available[ $slug ] ) ? array_keys( $available[ $slug ] ) : array();
 		$available[] = 'en_US';
 
 		return $available;
@@ -295,10 +295,10 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 		$translations = ! empty( $response['translations'] ) ? $response['translations'] : array();
 
 		$en_us = array(
-			'language' => 'en_US',
+			'language'     => 'en_US',
 			'english_name' => 'English (United States)',
-			'native_name' => 'English (United States)',
-			'updated' => '',
+			'native_name'  => 'English (United States)',
+			'updated'      => '',
 		);
 
 		$translations[] = $en_us;

--- a/src/WP_CLI/LanguagePackUpgrader.php
+++ b/src/WP_CLI/LanguagePackUpgrader.php
@@ -82,8 +82,8 @@ class LanguagePackUpgrader extends \Language_Pack_Upgrader {
 
 		$temp = \WP_CLI\Utils\get_temp_dir() . uniqid( 'wp_' ) . '.' . $ext;
 
-		$cache = WP_CLI::get_cache();
-		$cache_key = "translation/{$type}-{$slug}-{$version}-{$language}-{$updated}.{$ext}";
+		$cache      = WP_CLI::get_cache();
+		$cache_key  = "translation/{$type}-{$slug}-{$version}-{$language}-{$updated}.{$ext}";
 		$cache_file = $cache->has( $cache_key );
 
 		if ( $cache_file ) {


### PR DESCRIPTION
* Mostly whitespace;
* Use parentheses when instantiating a new object;
* Use `elseif`, not `else if`;
* Use single quotes when a text string does not contain interpolated variables;
* Use Yoda conditions;
* One assignment per statement;
* Use docblock format for inline `@var` comments.

Related to #73