### PR TITLE
PHPCS: fix up the code base [2] - strict comparisons

### DIFF
--- a/src/Core_Language_Command.php
+++ b/src/Core_Language_Command.php
@@ -93,7 +93,11 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 		$current_locale = get_locale();
 
 		$translations = array_map( function( $translation ) use ( $available, $current_locale, $updates ) {
-			$translation['status'] = ( in_array( $translation['language'], $available ) ) ? 'installed' : 'uninstalled';
+			$translation['status'] = 'uninstalled';
+			if ( in_array( $translation['language'], $available, true ) ) {
+				$translation['status'] = 'installed';
+			}
+
 			if ( $current_locale === $translation['language'] ) {
 				$translation['status'] = 'active';
 			}

--- a/src/Plugin_Language_Command.php
+++ b/src/Plugin_Language_Command.php
@@ -294,7 +294,7 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 			$assoc_args['format'] = 'table';
 		}
 
-		if ( in_array( $assoc_args['format'], array( 'json', 'csv' ) ) ) {
+		if ( in_array( $assoc_args['format'], array( 'json', 'csv' ), true ) ) {
 			$logger = new \WP_CLI\Loggers\Quiet();
 			\WP_CLI::set_logger( $logger );
 		}

--- a/src/Theme_Language_Command.php
+++ b/src/Theme_Language_Command.php
@@ -296,7 +296,7 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 			$assoc_args['format'] = 'table';
 		}
 
-		if ( in_array( $assoc_args['format'], array( 'json', 'csv' ) ) ) {
+		if ( in_array( $assoc_args['format'], array( 'json', 'csv' ), true ) ) {
 			$logger = new \WP_CLI\Loggers\Quiet();
 			\WP_CLI::set_logger( $logger );
 		}


### PR DESCRIPTION
Fixes relate to the following rules:
* Use the `$strict` parameter when calling `in_array()`.

Notes regarding the changes for the comparison in the `Core_Language_Command` file:
* I have verified that the contents of `$available` is expected to always be strings, so a strict comparison should be good here.
* As the line became even longer now, I have taken the liberty to rewrite it to something slightly more readable.

Related to #73