### PR TITLE
PHPCS: fix up the code base [4] - multi-line function calls

### DIFF
--- a/language-command.php
+++ b/language-command.php
@@ -34,9 +34,12 @@ WP_CLI::add_command(
 	array( 'before_invoke' => $wpcli_language_check_requirements )
 );
 
-WP_CLI::add_hook( 'after_add_command:site', function () {
-	WP_CLI::add_command( 'site switch-language', 'Site_Switch_Language_Command' );
-} );
+WP_CLI::add_hook(
+	'after_add_command:site',
+	function () {
+		WP_CLI::add_command( 'site switch-language', 'Site_Switch_Language_Command' );
+	}
+);
 
 if ( class_exists( 'WP_CLI\Dispatcher\CommandNamespace' ) ) {
 	WP_CLI::add_command( 'language', 'Language_Namespace' );

--- a/language-command.php
+++ b/language-command.php
@@ -16,16 +16,22 @@ $wpcli_language_check_requirements = function() {
 	}
 };
 
-WP_CLI::add_command( 'language core', 'Core_Language_Command', array(
-	'before_invoke' => $wpcli_language_check_requirements )
+WP_CLI::add_command(
+	'language core',
+	'Core_Language_Command',
+	array( 'before_invoke' => $wpcli_language_check_requirements )
 );
 
-WP_CLI::add_command( 'language plugin', 'Plugin_Language_Command', array(
-		'before_invoke' => $wpcli_language_check_requirements )
+WP_CLI::add_command(
+	'language plugin',
+	'Plugin_Language_Command',
+	array( 'before_invoke' => $wpcli_language_check_requirements )
 );
 
-WP_CLI::add_command( 'language theme', 'Theme_Language_Command', array(
-		'before_invoke' => $wpcli_language_check_requirements )
+WP_CLI::add_command(
+	'language theme',
+	'Theme_Language_Command',
+	array( 'before_invoke' => $wpcli_language_check_requirements )
 );
 
 WP_CLI::add_hook( 'after_add_command:site', function () {

--- a/src/Core_Language_Command.php
+++ b/src/Core_Language_Command.php
@@ -92,25 +92,28 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 
 		$current_locale = get_locale();
 
-		$translations = array_map( function( $translation ) use ( $available, $current_locale, $updates ) {
-			$translation['status'] = 'uninstalled';
-			if ( in_array( $translation['language'], $available, true ) ) {
-				$translation['status'] = 'installed';
-			}
+		$translations = array_map(
+			function( $translation ) use ( $available, $current_locale, $updates ) {
+				$translation['status'] = 'uninstalled';
+				if ( in_array( $translation['language'], $available, true ) ) {
+					$translation['status'] = 'installed';
+				}
 
-			if ( $current_locale === $translation['language'] ) {
-				$translation['status'] = 'active';
-			}
+				if ( $current_locale === $translation['language'] ) {
+					$translation['status'] = 'active';
+				}
 
-			$update = wp_list_filter( $updates, array( 'language' => $translation['language'] ) );
-			if ( $update ) {
-				$translation['update'] = 'available';
-			} else {
-				$translation['update'] = 'none';
-			}
+				$update = wp_list_filter( $updates, array( 'language' => $translation['language'] ) );
+				if ( $update ) {
+					$translation['update'] = 'available';
+				} else {
+					$translation['update'] = 'none';
+				}
 
-			return $translation;
-		}, $translations );
+				return $translation;
+			},
+			$translations
+		);
 
 		foreach ( $translations as $key => $translation ) {
 			foreach ( array_keys( $translation ) as $field ) {

--- a/src/Core_Language_Command.php
+++ b/src/Core_Language_Command.php
@@ -102,9 +102,7 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 				$translation['status'] = 'active';
 			}
 
-			$update = wp_list_filter( $updates, array(
-				'language' => $translation['language']
-			) );
+			$update = wp_list_filter( $updates, array( 'language' => $translation['language'] ) );
 			if ( $update ) {
 				$translation['update'] = 'available';
 			} else {

--- a/src/Plugin_Language_Command.php
+++ b/src/Plugin_Language_Command.php
@@ -122,11 +122,12 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 					$translation['status'] = 'active';
 				}
 
-				$update = wp_list_filter( $updates, array(
+				$filter_args = array(
 					'language' => $translation['language'],
 					'type'     => 'plugin',
 					'slug'     => $plugin,
-				) );
+				);
+				$update      = wp_list_filter( $updates, $filter_args );
 
 				$translation['update'] = $update ? 'available' : 'none';
 

--- a/src/Theme_Language_Command.php
+++ b/src/Theme_Language_Command.php
@@ -97,9 +97,12 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 		}
 
 		if ( $all ) {
-			$args = array_map( function( $file ){
-				return \WP_CLI\Utils\get_theme_name( $file );
-			}, array_keys( wp_get_themes() ) );
+			$args = array_map(
+				function( $file ) {
+					return \WP_CLI\Utils\get_theme_name( $file );
+				},
+				array_keys( wp_get_themes() )
+			);
 
 			if ( empty( $args ) ) {
 				WP_CLI::success( 'No themes installed.' );

--- a/src/Theme_Language_Command.php
+++ b/src/Theme_Language_Command.php
@@ -124,11 +124,12 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 					$translation['status'] = 'active';
 				}
 
-				$update = wp_list_filter( $updates, array(
+				$filter_args = array(
 					'language' => $translation['language'],
 					'type'     => 'theme',
 					'slug'     => $theme,
-				) );
+				);
+				$update      = wp_list_filter( $updates, $filter_args );
 
 				$translation['update'] = $update ? 'available' : 'none';
 

--- a/src/WP_CLI/CommandWithTranslation.php
+++ b/src/WP_CLI/CommandWithTranslation.php
@@ -66,9 +66,7 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 				}
 
 				// Gets the translation data.
-				$translation = wp_list_filter( $all_languages, array(
-					'language' => $update->language
-				) );
+				$translation = wp_list_filter( $all_languages, array( 'language' => $update->language ) );
 				$translation = (object) reset( $translation );
 
 				$update->Type    = ucfirst( $update->type );


### PR DESCRIPTION
Fixes relate to the following rules:
* Each argument in a multiline function call should start on a new line.

Committed in four parts, each commits applies a different solution based on what's most appropriate for the specific code snippets involved.

Please refer to the individual commits for more details.

Related to #73 