### PR TITLE
Implement CS checking based on the `WP_CLI_CS` ruleset 

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -6,6 +6,8 @@
 .travis.yml
 behat.yml
 circle.yml
+phpcs.xml.dist
+phpunit.xml.dist
 bin/
 features/
 utils/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ vendor/
 *.tar.gz
 composer.lock
 *.log
+phpunit.xml
+phpcs.xml
+.phpcs.xml

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "wp-cli/db-command": "^1.3 || ^2",
         "wp-cli/entity-command": "^1.3 || ^2",
         "wp-cli/extension-command": "^1.2 || ^2",
-        "wp-cli/wp-cli-tests": "^2.0.7"
+        "wp-cli/wp-cli-tests": "^2.1"
     },
     "config": {
         "process-timeout": 7200,

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,86 @@
+<?xml version="1.0"?>
+<ruleset name="WP-CLI-language">
+	<description>Custom ruleset for WP-CLI language-command</description>
+
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	For help understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	For help using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage
+	#############################################################################
+	-->
+
+	<!-- What to scan. -->
+	<file>.</file>
+
+	<!-- Show progress. -->
+	<arg value="p"/>
+
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check up to 8 files simultaneously. -->
+	<arg name="parallel" value="8"/>
+
+	<!--
+	#############################################################################
+	USE THE WP_CLI_CS RULESET
+	#############################################################################
+	-->
+
+	<rule ref="WP_CLI_CS"/>
+
+	<!--
+	#############################################################################
+	PROJECT SPECIFIC CONFIGURATION FOR SNIFFS
+	#############################################################################
+	-->
+
+	<!-- For help understanding the `testVersion` configuration setting:
+		 https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
+	<config name="testVersion" value="5.4-"/>
+
+	<!-- Verify that everything in the global namespace is either namespaced or prefixed.
+		 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array">
+				<element value="WP_CLI\Language"/><!-- Namespaces. -->
+				<element value="wpcli_language"/><!-- Global variables and such. -->
+			</property>
+		</properties>
+	</rule>
+
+	<!--
+	#############################################################################
+	SELECTIVE EXCLUSIONS
+	#############################################################################
+	-->
+
+	<!-- The objects containing these properties come from the wordpress.org API, so cannot be renamed.
+		 Used in file: CommandWithTranslation.php.
+		 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#mixed-case-property-name-exceptions
+		 Related: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1623 -->
+	<rule ref="WordPress.NamingConventions.ValidVariableName">
+		<properties>
+			<property name="customPropertiesWhitelist" type="array">
+				<element value="Language"/>
+				<element value="Name"/>
+				<element value="Type"/>
+				<element value="Version"/>
+			</property>
+		</properties>
+	</rule>
+
+	<!-- Exclude existing namespaces from the prefix rule as it would break BC to prefix them now. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound">
+		<exclude-pattern>*/src/WP_CLI/(CommandWithTranslation|LanguagePackUpgrader)\.php$</exclude-pattern>
+	</rule>
+
+	<!-- Exclude existing classes from the prefix rule as it would break BC to prefix them now. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound">
+		<exclude-pattern>*/src/(Core|Plugin|Site_Switch|Theme)_Language_Command\.php$</exclude-pattern>
+		<exclude-pattern>*/src/Language_Namespace\.php$</exclude-pattern>
+	</rule>
+
+</ruleset>

--- a/src/Core_Language_Command.php
+++ b/src/Core_Language_Command.php
@@ -311,7 +311,7 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 	 *
 	 * @subcommand update
 	 */
-	public function update( $args, $assoc_args ) {
+	public function update( $args, $assoc_args ) { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found -- Overruling the documentation, so not useless ;-).
 		parent::update( $args, $assoc_args );
 	}
 

--- a/src/Plugin_Language_Command.php
+++ b/src/Plugin_Language_Command.php
@@ -466,6 +466,7 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 	 * @return array
 	 */
 	private function get_all_plugins() {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Using WP native hook.
 		return apply_filters( 'all_plugins', get_plugins() );
 	}
 }

--- a/src/WP_CLI/LanguagePackUpgrader.php
+++ b/src/WP_CLI/LanguagePackUpgrader.php
@@ -57,8 +57,12 @@ class LanguagePackUpgrader extends \Language_Pack_Upgrader {
 		 * @param bool          $reply   Whether to bail without returning the package. Default is false.
 		 * @param string        $package The package file name.
 		 * @param \WP_Upgrader  $this    The WP_Upgrader instance.
+		 *
+		 * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Using WP native hook.
 		 */
 		$reply = apply_filters( 'upgrader_pre_download', false, $package, $this );
+		// phpcs:enable
+
 		if ( false !== $reply ) {
 			return $reply;
 		}


### PR DESCRIPTION
This adds a PHPCS ruleset using the new WP_CLI_CS standard and adds some select whitelist comments.

Please see the individual commits for more detail.

Fixes #73

Related to wp-cli/wp-cli#5179

----

There are issues remaining for which I would like a second opinion on how to fix these:

```
FILE: src\Language_Namespace.php
------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
------------------------------------------------------------------------------------------
 26 | ERROR | Classes declared by a theme/plugin should start with the theme/plugin
    |       | prefix. Found: "Language_Namespace".
    |       | (WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound)
------------------------------------------------------------------------------------------
```

:point_up:  As this is _not_ a command, I'm wondering if the class can be renamed.

```
FILE: src\WP_CLI\CommandWithTranslation.php
------------------------------------------------------------------------------------------
FOUND 5 ERRORS AFFECTING 5 LINES
------------------------------------------------------------------------------------------
  3 | ERROR | Namespaces declared by a theme/plugin should start with the theme/plugin
    |       | prefix. Found: "WP_CLI".
    |       | (WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound)
 72 | ERROR | Object property "$Type" is not in valid snake_case format, try "$type"
    |       | (WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase)
 73 | ERROR | Object property "$Name" is not in valid snake_case format, try "$name"
    |       | (WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase)
 74 | ERROR | Object property "$Version" is not in valid snake_case format, try
    |       | "$version"
    |       | (WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase)
 77 | ERROR | Object property "$Language" is not in valid snake_case format, try
    |       | "$language"
    |       | (WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase)
------------------------------------------------------------------------------------------
```
:point_up: Regarding the object properties - these appear to be `stdClass` objects (based on visual code inspection only). If that's correct, I'm wondering if we can't just fix those rather than whitelist, though I'm open to whitelisting these.

```
FILE: src\WP_CLI\LanguagePackUpgrader.php
------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
------------------------------------------------------------------------------------------
 3 | ERROR | Namespaces declared by a theme/plugin should start with the theme/plugin
   |       | prefix. Found: "WP_CLI".
   |       | (WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound)
------------------------------------------------------------------------------------------
```

:point_up: Here and in the previous file - these files are not the commands, so I'm wondering if we can fix the namespace rather whitelist it.