### PR TITLE
Change `LanguagePackUpgrader::download_package` signature

### DIFF
--- a/src/WP_CLI/LanguagePackUpgrader.php
+++ b/src/WP_CLI/LanguagePackUpgrader.php
@@ -47,7 +47,7 @@ class LanguagePackUpgrader extends \Language_Pack_Upgrader {
 	 *                        existing local file, it will be returned untouched.
 	 * @return string|\WP_Error The full path to the downloaded package file, or a WP_Error object.
 	 */
-	public function download_package( $package ) {
+	public function download_package( $package, $check_signatures = false ) {
 
 		/**
 		 * Filter whether to return the package.

--- a/src/WP_CLI/LanguagePackUpgrader.php
+++ b/src/WP_CLI/LanguagePackUpgrader.php
@@ -45,6 +45,7 @@ class LanguagePackUpgrader extends \Language_Pack_Upgrader {
 	 *
 	 * @param string $package The URI of the package. If this is the full path to an
 	 *                        existing local file, it will be returned untouched.
+	 * @param bool   $check_signatures Whether to validate file signatures. Default false.
 	 * @return string|\WP_Error The full path to the downloaded package file, or a WP_Error object.
 	 */
 	public function download_package( $package, $check_signatures = false ) {

--- a/src/WP_CLI/LanguagePackUpgrader.php
+++ b/src/WP_CLI/LanguagePackUpgrader.php
@@ -43,8 +43,8 @@ class LanguagePackUpgrader extends \Language_Pack_Upgrader {
 	/**
 	 * Caches the download, and uses cached if available.
 	 *
-	 * @param string $package The URI of the package. If this is the full path to an
-	 *                        existing local file, it will be returned untouched.
+	 * @param string $package          The URI of the package. If this is the full path to an
+	 *                                 existing local file, it will be returned untouched.
 	 * @param bool   $check_signatures Whether to validate file signatures. Default false.
 	 * @return string|\WP_Error The full path to the downloaded package file, or a WP_Error object.
 	 */


### PR DESCRIPTION
Adapts `WP_CLI\LanguagePackUpgrader::download_package` signature to changes in WordPress trunk.

Fixes #81 