### PR TITLE
Enforce PHP 7.4 compatibility in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 dist: trusty
 
 language: php
-php: 7.3
+php: 7.4
 
 notifications:
   email:
@@ -51,7 +51,7 @@ jobs:
         - composer phpcs
       env: BUILD=sniff
     - stage: test
-      php: 7.4snapshot
+      php: 7.4
       env: WP_VERSION=latest
     - stage: test
       php: 7.3
@@ -78,7 +78,3 @@ jobs:
       php: 5.4
       dist: precise
       env: WP_VERSION=5.1
-  allow_failures:
-    - stage: test
-      php: 7.4snapshot
-      env: WP_VERSION=latest

--- a/src/WP_CLI/CommandWithTranslation.php
+++ b/src/WP_CLI/CommandWithTranslation.php
@@ -277,10 +277,14 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 			if ( 'plugins' === $this->obj_type ) {
 				$plugins         = get_plugins( '/' . $slug );
 				$plugin_data     = array_shift( $plugins );
-				$args['version'] = $plugin_data['Version'];
+				if ( isset( $plugin_data['Version'] ) ) {
+					$args['version'] = $plugin_data['Version'];
+				}
 			} elseif ( 'themes' === $this->obj_type ) {
 				$theme_data      = wp_get_theme( $slug );
-				$args['version'] = $theme_data['Version'];
+				if ( isset( $theme_data['Version'] ) ) {
+					$args['version'] = $theme_data['Version'];
+				}
 			}
 		}
 

--- a/src/WP_CLI/CommandWithTranslation.php
+++ b/src/WP_CLI/CommandWithTranslation.php
@@ -275,13 +275,13 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 			$args['slug'] = $slug;
 
 			if ( 'plugins' === $this->obj_type ) {
-				$plugins         = get_plugins( '/' . $slug );
-				$plugin_data     = array_shift( $plugins );
+				$plugins     = get_plugins( '/' . $slug );
+				$plugin_data = array_shift( $plugins );
 				if ( isset( $plugin_data['Version'] ) ) {
 					$args['version'] = $plugin_data['Version'];
 				}
 			} elseif ( 'themes' === $this->obj_type ) {
-				$theme_data      = wp_get_theme( $slug );
+				$theme_data = wp_get_theme( $slug );
 				if ( isset( $theme_data['Version'] ) ) {
 					$args['version'] = $theme_data['Version'];
 				}


### PR DESCRIPTION
This PR changes the Travis CI configuration to use PHP 7.4 for all main tests nd switches the PHP 7.4 tests from allowing failures to failing the build on errors.

It will also include any fixes that might be required to get the tests to pass.