### PR TITLE
add `$hook_extra` to LanguagePackUpgrader::download_package.

### DIFF
--- a/src/WP_CLI/LanguagePackUpgrader.php
+++ b/src/WP_CLI/LanguagePackUpgrader.php
@@ -46,9 +46,10 @@ class LanguagePackUpgrader extends \Language_Pack_Upgrader {
 	 * @param string $package          The URI of the package. If this is the full path to an
 	 *                                 existing local file, it will be returned untouched.
 	 * @param bool   $check_signatures Whether to validate file signatures. Default false.
+	 * @param array  $hook_extra       Extra arguments to pass to the filter hooks. Default empty array.
 	 * @return string|\WP_Error The full path to the downloaded package file, or a WP_Error object.
 	 */
-	public function download_package( $package, $check_signatures = false ) {
+	public function download_package( $package, $check_signatures = false, $hook_extra = array() ) {
 
 		/**
 		 * Filter whether to return the package.

--- a/src/WP_CLI/LanguagePackUpgrader.php
+++ b/src/WP_CLI/LanguagePackUpgrader.php
@@ -49,20 +49,22 @@ class LanguagePackUpgrader extends \Language_Pack_Upgrader {
 	 * @param array  $hook_extra       Extra arguments to pass to the filter hooks. Default empty array.
 	 * @return string|\WP_Error The full path to the downloaded package file, or a WP_Error object.
 	 */
-	public function download_package( $package, $check_signatures = false, $hook_extra = array() ) {
+	public function download_package( $package, $check_signatures = false, $hook_extra = [] ) {
 
 		/**
 		 * Filter whether to return the package.
 		 *
 		 * @since 3.7.0
+		 * @since 5.5.0 Added the `$hook_extra` parameter.
 		 *
-		 * @param bool          $reply   Whether to bail without returning the package. Default is false.
-		 * @param string        $package The package file name.
-		 * @param \WP_Upgrader  $this    The WP_Upgrader instance.
+		 * @param bool          $reply      Whether to bail without returning the package. Default is false.
+		 * @param string        $package    The package file name.
+		 * @param \WP_Upgrader  $this       The WP_Upgrader instance.
+		 * @param array         $hook_extra Extra arguments passed to hooked filters.
 		 *
 		 * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Using WP native hook.
 		 */
-		$reply = apply_filters( 'upgrader_pre_download', false, $package, $this );
+		$reply = apply_filters( 'upgrader_pre_download', false, $package, $this, $hook_extra );
 		// phpcs:enable
 
 		if ( false !== $reply ) {


### PR DESCRIPTION
Fix PHP Warning with WP 5.5.

In WordPress 5.5, the argument `$hook_extra` has been added to WP_Upgrader::download_package.


```
PHP Warning:  Declaration of WP_CLI\LanguagePackUpgrader::download_package($package, $check_signatures = false) should be compatible with WP_Upgrader::download_package($package, $check_signatures = false, $hook_extra = Array) in phar:///usr/local/bin/wp/vendor/wp-cli/language-command/src/WP_CLI/LanguagePackUpgrader.php on line 51
```

