### PR TITLE
Add warning for nonexistent plugins

### DIFF
--- a/features/language-plugin.feature
+++ b/features/language-plugin.feature
@@ -20,6 +20,16 @@ Feature: Manage translation files for a WordPress install
       | en_US     | English (United States) | active        |
       | en_GB     | English (UK)            | uninstalled   |
 
+    When I try `wp language plugin list not-a-plugin --format=json`
+    Then STDOUT should be:
+      """
+      []
+      """
+    And STDERR should contain:
+      """
+      Warning: Plugin 'not-a-plugin' not found.
+      """
+
     When I try `wp language plugin is-installed hello-dolly en_GB`
     Then the return code should be 1
     And STDERR should be empty

--- a/features/language-theme.feature
+++ b/features/language-theme.feature
@@ -19,6 +19,16 @@ Feature: Manage translation files for a WordPress install
       | en_US     | English (United States) | active        |
       | en_GB     | English (UK)            | uninstalled   |
 
+    When I try `wp language theme list not-a-theme --format=json`
+    Then STDOUT should be:
+      """
+      []
+      """
+    And STDERR should contain:
+      """
+      Warning: Theme 'not-a-theme' not found.
+      """
+
     When I try `wp language theme is-installed twentyten en_GB`
     Then the return code should be 1
     And STDERR should be empty

--- a/src/Plugin_Language_Command.php
+++ b/src/Plugin_Language_Command.php
@@ -324,10 +324,10 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 			$available = $this->get_installed_languages( $plugin_name );
 
 			foreach ( $language_codes as $language_code ) {
-				$result = array(
+				$result = [
 					'name'   => $plugin_name,
 					'locale' => $language_code,
-				);
+				];
 
 				if ( in_array( $language_code, $available, true ) ) {
 					\WP_CLI::log( "Language '{$language_code}' for '{$plugin_details['Name']}' already installed." );

--- a/src/Plugin_Language_Command.php
+++ b/src/Plugin_Language_Command.php
@@ -109,8 +109,14 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 		$current_locale = get_locale();
 
 		$translations = array();
+		$plugins      = new \WP_CLI\Fetchers\Plugin();
 
 		foreach ( $args as $plugin ) {
+			if ( ! $plugins->get( $plugin ) ) {
+				WP_CLI::warning( "Plugin '{$plugin}' not found." );
+				continue;
+			}
+
 			$installed_translations = $this->get_installed_languages( $plugin );
 			$available_translations = $this->get_all_languages( $plugin );
 
@@ -318,10 +324,10 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 			$available = $this->get_installed_languages( $plugin_name );
 
 			foreach ( $language_codes as $language_code ) {
-				$result = [
+				$result = array(
 					'name'   => $plugin_name,
 					'locale' => $language_code,
-				];
+				);
 
 				if ( in_array( $language_code, $available, true ) ) {
 					\WP_CLI::log( "Language '{$language_code}' for '{$plugin_details['Name']}' already installed." );

--- a/src/Theme_Language_Command.php
+++ b/src/Theme_Language_Command.php
@@ -114,8 +114,15 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 		$current_locale = get_locale();
 
 		$translations = array();
+		$themes      = new \WP_CLI\Fetchers\Theme();
 
 		foreach ( $args as $theme ) {
+
+			if ( ! $themes->get( $theme ) ) {
+				WP_CLI::warning( "Theme '{$theme}' not found." );
+				continue;
+			}
+
 			$installed_translations = $this->get_installed_languages( $theme );
 			$available_translations = $this->get_all_languages( $theme );
 

--- a/src/Theme_Language_Command.php
+++ b/src/Theme_Language_Command.php
@@ -114,7 +114,7 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 		$current_locale = get_locale();
 
 		$translations = array();
-		$themes      = new \WP_CLI\Fetchers\Theme();
+		$themes       = new \WP_CLI\Fetchers\Theme();
 
 		foreach ( $args as $theme ) {
 


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

- Adds a check to see if a plugin is installed before checking languages
- If the plugin isn't installed, displays a warning
- Adds a test to confirm this continues to work
- Made some updates for themes

Fixes #86 