### PR TITLE
Add deprecation hint in `wp language core activate`'s docblock

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,13 @@ wp language core
 
 ### wp language core activate
 
-Activates a given language. (Deprecated: use wp site switch-language instead)
+Activates a given language.
 
 ~~~
 wp language core activate <language>
 ~~~
+
+**Warning: `wp language core activate` is deprecated. Use `wp site switch-language` instead.**
 
 **OPTIONS**
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ wp language core
 
 ### wp language core activate
 
-Activates a given language.
+Activates a given language. (Deprecated: use wp site switch-language instead)
 
 ~~~
 wp language core activate <language>

--- a/src/Core_Language_Command.php
+++ b/src/Core_Language_Command.php
@@ -316,7 +316,9 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 	}
 
 	/**
-	 * Activates a given language. (Deprecated: use wp site switch-language instead)
+	 * Activates a given language.
+	 *
+	 * **Warning: `wp language core activate` is deprecated.**
 	 *
 	 * ## OPTIONS
 	 *

--- a/src/Core_Language_Command.php
+++ b/src/Core_Language_Command.php
@@ -318,7 +318,7 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 	/**
 	 * Activates a given language.
 	 *
-	 * **Warning: `wp language core activate` is deprecated.**
+	 * **Warning: `wp language core activate` is deprecated. Use `wp site switch-language` instead.**
 	 *
 	 * ## OPTIONS
 	 *

--- a/src/Core_Language_Command.php
+++ b/src/Core_Language_Command.php
@@ -316,7 +316,7 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 	}
 
 	/**
-	 * Activates a given language.
+	 * Activates a given language. (Deprecated: use wp site switch-language instead)
 	 *
 	 * ## OPTIONS
 	 *


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

## Description

- This PR adds a deprecation hint to `wp language core activate`'s docblock & Readme.md file as suggested [in this comment](https://github.com/wp-cli/language-command/issues/94#issuecomment-1630560508).

## Screenshots of output

1. #### Command: `wp language core activate --help`

    - ##### Before

        - Synopsis text: 
           ```
           wp language core activate <language>
           ```

           <img width="1427" alt="Screenshot 2023-08-27 at 8 38 16 PM" src="https://github.com/wp-cli/language-command/assets/63953699/78223ee3-e8f6-4602-8413-7e1360982a81">


    - ##### After

        - Synopsis text: 
           ```
           wp language core activate <language>

           **Warning: 'wp language core activate is deprecated.**
           ```

           <img width="1427" alt="Screenshot 2023-08-27 at 8 35 44 PM" src="https://github.com/wp-cli/language-command/assets/63953699/09d09663-5b9d-4086-9a27-7bd9555bde2f">

## Fixes/Covers
- https://github.com/wp-cli/language-command/issues/94