### PR TITLE
Allow for PHP 8.2+ warning on old WP core

### DIFF
--- a/features/language-core.feature
+++ b/features/language-core.feature
@@ -304,11 +304,17 @@ Feature: Manage translation files for a WordPress install
     And an empty cache
     And I run `wp core download --version=4.5.3 --force`
 
-    When I run `wp language core install nl_NL`
+    # PHP 8.2+ will show a warning for old WordPress core version.
+    When I try `wp language core install nl_NL`
     Then STDOUT should contain:
       """
       Downloading translation from https://downloads.wordpress.org/translation/core/4.5.3
       """
+    And STDOUT should contain:
+      """
+      Success: Installed 1 of 1 languages.
+      """
+    And the return code should be 0
 
   @require-wp-4.0
   Scenario: Ensure upgrader output is in English


### PR DESCRIPTION
A `language install` test is producing a PHP 8.2+ warning for WordPress core 4.5 used in the test.

This PR makes the test ignore the warning while still verifying success.