### PR TITLE
Re-enable some tests for SQLite

### DIFF
--- a/features/language-plugin.feature
+++ b/features/language-plugin.feature
@@ -220,8 +220,7 @@ Feature: Manage translation files for a WordPress install
     And STDOUT should be empty
     And the return code should be 0
 
-  # An empty plugin directory breaks SQLite integration, which uses a plugin.
-  @require-wp-4.0 @require-mysql
+  @require-wp-4.0
   Scenario: Not providing plugin slugs should throw an error unless --all given
     Given a WP install
     And I run `wp plugin path`
@@ -386,8 +385,7 @@ Feature: Manage translation files for a WordPress install
     And STDERR should be empty
 
 
-  # An empty plugin directory breaks SQLite integration, which uses a plugin.
-  @require-wp-4.0 @require-mysql
+  @require-wp-4.0
   Scenario: Install translations for all installed plugins
     Given a WP install
     And I run `wp plugin path`


### PR DESCRIPTION
Now that the SQLite integration is loaded via mu-plugins, we can re-enable these tests again

Related: https://github.com/wp-cli/wp-cli/issues/5859
