### PR TITLE
Properly delete JSON & PHP translation files

### DIFF
--- a/features/language-core.feature
+++ b/features/language-core.feature
@@ -165,6 +165,7 @@ Feature: Manage translation files for a WordPress install
     When I run `wp language core uninstall en_GB`
     Then the wp-content/languages/admin-en_GB.po file should not exist
     And the wp-content/languages/en_GB.po file should not exist
+    And the wp-content/languages/en_GB.l10n.php file should not exist
     And STDOUT should be:
       """
       Success: Language uninstalled.
@@ -173,8 +174,10 @@ Feature: Manage translation files for a WordPress install
     When I run `wp language core uninstall en_CA ja`
      Then the wp-content/languages/admin-en_CA.po file should not exist
      And the wp-content/languages/en_CA.po file should not exist
+     And the wp-content/languages/en_CA.l10n.php file should not exist
      And the wp-content/languages/admin-ja.po file should not exist
      And the wp-content/languages/ja.po file should not exist
+     And the wp-content/languages/ja.l10n.php file should not exist
      And STDOUT should be:
        """
       Success: Language uninstalled.

--- a/features/language-plugin.feature
+++ b/features/language-plugin.feature
@@ -125,8 +125,10 @@ Feature: Manage translation files for a WordPress install
     When I run `wp language plugin uninstall hello-dolly cs_CZ de_DE`
     Then the wp-content/languages/plugins/hello-dolly-cs_CZ.po file should not exist
     And the wp-content/languages/plugins/hello-dolly-cs_CZ.mo file should not exist
+    And the wp-content/languages/plugins/hello-dolly-cs_CZ.l10n.php file should not exist
     And the wp-content/languages/plugins/hello-dolly-de_DE.po file should not exist
     And the wp-content/languages/plugins/hello-dolly-de_DE.mo file should not exist
+    And the wp-content/languages/plugins/hello-dolly-de_DE.l10n.php file should not exist
     And STDOUT should contain:
       """
       Language 'cs_CZ' for 'hello-dolly' uninstalled.

--- a/features/language-theme.feature
+++ b/features/language-theme.feature
@@ -119,8 +119,10 @@ Feature: Manage translation files for a WordPress install
     When I run `wp language theme uninstall twentyten cs_CZ de_DE`
     Then the wp-content/languages/themes/twentyten-cs_CZ.po file should not exist
     And the wp-content/languages/themes/twentyten-cs_CZ.mo file should not exist
+    And the wp-content/languages/themes/twentyten-cs_CZ.l10n.php file should not exist
     And the wp-content/languages/themes/twentyten-de_DE.po file should not exist
     And the wp-content/languages/themes/twentyten-de_DE.mo file should not exist
+    And the wp-content/languages/themes/twentyten-de_DE.l10n.php file should not exist
       """
       Success: Language 'cs_CZ' for 'twentyten' uninstalled.
       Success: Language 'de_DE' for 'twentyten' uninstalled.

--- a/src/Core_Language_Command.php
+++ b/src/Core_Language_Command.php
@@ -293,7 +293,7 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 
 				if (
 					! in_array( $file, $files_to_remove, true ) &&
-					! preg_match( "$language_code-\w{32}\.json", $file )
+					! preg_match( "/$language_code-\w{32}\.json/", $file )
 				) {
 					continue;
 				}

--- a/src/Core_Language_Command.php
+++ b/src/Core_Language_Command.php
@@ -260,16 +260,12 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 
 		foreach ( $language_codes as $language_code ) {
 			if ( ! in_array( $language_code, $available, true ) ) {
-				if ( count( $language_codes ) === 1 ) {
-					WP_CLI::error( 'Language not installed.' );
-				} else {
-					WP_CLI::warning( 'Language not installed.' );
-				}
+				WP_CLI::warning( 'Language not installed.' );
 			}
 
 			if ( $language_code === $current_locale ) {
 				WP_CLI::warning( "The '{$language_code}' language is active." );
-				continue;
+				exit;
 			}
 
 			$files_to_remove = array(

--- a/src/Core_Language_Command.php
+++ b/src/Core_Language_Command.php
@@ -260,7 +260,7 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 
 		foreach ( $language_codes as $language_code ) {
 			if ( ! in_array( $language_code, $available, true ) ) {
-				WP_CLI::warning( 'Language not installed.' );
+				WP_CLI::error( 'Language not installed.' );
 			}
 
 			if ( $language_code === $current_locale ) {

--- a/src/Core_Language_Command.php
+++ b/src/Core_Language_Command.php
@@ -246,27 +246,46 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 	public function uninstall( $args, $assoc_args ) {
 		global $wp_filesystem;
 
+		$dir   = 'core' === $this->obj_type ? '' : "/$this->obj_type";
+		$files = scandir( WP_LANG_DIR . $dir );
+		if ( ! $files ) {
+			WP_CLI::error( 'No files found in language directory.' );
+		}
+
 		$language_codes = (array) $args;
 
 		$available = $this->get_installed_languages();
 
+		$current_locale = get_locale();
+
 		foreach ( $language_codes as $language_code ) {
-
 			if ( ! in_array( $language_code, $available, true ) ) {
-				WP_CLI::error( 'Language not installed.' );
+				if ( count( $language_codes ) === 1 ) {
+					WP_CLI::error( 'Language not installed.' );
+				} else {
+					WP_CLI::warning( 'Language not installed.' );
+				}
 			}
 
-			$dir   = 'core' === $this->obj_type ? '' : "/$this->obj_type";
-			$files = scandir( WP_LANG_DIR . $dir );
-			if ( ! $files ) {
-				WP_CLI::error( 'No files found in language directory.' );
-			}
-
-			$current_locale = get_locale();
 			if ( $language_code === $current_locale ) {
 				WP_CLI::warning( "The '{$language_code}' language is active." );
-				exit;
+				continue;
 			}
+
+			$files_to_remove = array(
+				"$language_code.po",
+				"$language_code.mo",
+				"$language_code.l10n.php",
+				"admin-$language_code.po",
+				"admin-$language_code.mo",
+				"admin-$language_code.l10n.php",
+				"admin-network-$language_code.po",
+				"admin-network-$language_code.mo",
+				"admin-network-$language_code.l10n.php",
+				"continents-cities-$language_code.po",
+				"continents-cities-$language_code.mo",
+				"continents-cities-$language_code.l10n.php",
+			);
 
 			// As of WP 4.0, no API for deleting a language pack
 			WP_Filesystem();
@@ -275,9 +294,11 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 				if ( '.' === $file[0] || is_dir( $file ) ) {
 					continue;
 				}
-				$extension_length = strlen( $language_code ) + 4;
-				$ending           = substr( $file, -$extension_length );
-				if ( ! in_array( $file, array( $language_code . '.po', $language_code . '.mo' ), true ) && ! in_array( $ending, array( '-' . $language_code . '.po', '-' . $language_code . '.mo' ), true ) ) {
+
+				if (
+					! in_array( $file, $files_to_remove, true ) &&
+					! preg_match( "$language_code-\w{32}\.json", $file )
+				) {
 					continue;
 				}
 

--- a/src/Plugin_Language_Command.php
+++ b/src/Plugin_Language_Command.php
@@ -491,7 +491,7 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 
 					if (
 						! in_array( $file, $files_to_remove, true ) &&
-						! preg_match( "$plugin-$language_code-\w{32}\.json", $file )
+						! preg_match( "/$plugin-$language_code-\w{32}\.json/", $file )
 					) {
 						continue;
 					}

--- a/src/Plugin_Language_Command.php
+++ b/src/Plugin_Language_Command.php
@@ -481,8 +481,9 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 					"$plugin-$language_code.l10n.php",
 				);
 
-				$count_files_removed = 0;
-				$had_one_file        = false;
+				$count_files_to_remove = 0;
+				$count_files_removed   = 0;
+				$had_one_file          = false;
 
 				foreach ( $files as $file ) {
 					if ( '.' === $file[0] || is_dir( $file ) ) {
@@ -498,6 +499,8 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 
 					$had_one_file = true;
 
+					++$count_files_to_remove;
+
 					if ( $wp_filesystem->delete( WP_LANG_DIR . $dir . '/' . $file ) ) {
 						++$count_files_removed;
 					} else {
@@ -505,7 +508,7 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 					}
 				}
 
-				if ( count( $files_to_remove ) === $count_files_removed ) {
+				if ( $count_files_to_remove === $count_files_removed ) {
 					$result['status'] = 'uninstalled';
 					++$successes;
 					\WP_CLI::log( "Language '{$language_code}' for '{$plugin}' uninstalled." );

--- a/src/Plugin_Language_Command.php
+++ b/src/Plugin_Language_Command.php
@@ -501,7 +501,7 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 
 					++$count_files_to_remove;
 
-					if ( $wp_filesystem->delete( WP_LANG_DIR . $dir . '/' . $file ) ) {
+					if ( $wp_filesystem->delete( $dir . '/' . $file ) ) {
 						++$count_files_removed;
 					} else {
 						\WP_CLI::error( "Couldn't uninstall language: $language_code from plugin $plugin." );

--- a/src/Plugin_Language_Command.php
+++ b/src/Plugin_Language_Command.php
@@ -472,7 +472,7 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 
 				if ( $language_code === $current_locale ) {
 					\WP_CLI::warning( "The '{$language_code}' language is active." );
-					continue;
+					exit;
 				}
 
 				$files_to_remove = array(

--- a/src/Theme_Language_Command.php
+++ b/src/Theme_Language_Command.php
@@ -486,21 +486,33 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 					exit;
 				}
 
-				$po_file = "{$dir}/{$theme}-{$language_code}.po";
-				$mo_file = "{$dir}/{$theme}-{$language_code}.mo";
-
-				$files_to_remove = array( $po_file, $mo_file );
+				$files_to_remove = array(
+					"$theme-$language_code.po",
+					"$theme-$language_code.mo",
+					"$theme-$language_code.l10n.php",
+				);
 
 				$count_files_removed = 0;
-				$had_one_file        = 0;
-				foreach ( $files_to_remove as $file ) {
-					if ( $wp_filesystem->exists( $file ) ) {
-						$had_one_file = 1;
-						if ( $wp_filesystem->delete( $file ) ) {
-							++$count_files_removed;
-						} else {
-							\WP_CLI::error( "Couldn't uninstall language: $language_code from theme $theme." );
-						}
+				$had_one_file        = false;
+
+				foreach ( $files as $file ) {
+					if ( '.' === $file[0] || is_dir( $file ) ) {
+						continue;
+					}
+
+					if (
+						! in_array( $file, $files_to_remove, true ) &&
+						! preg_match( "$theme-$language_code-\w{32}\.json", $file )
+					) {
+						continue;
+					}
+
+					$had_one_file = true;
+
+					if ( $wp_filesystem->delete( WP_LANG_DIR . $dir . '/' . $file ) ) {
+						++$count_files_removed;
+					} else {
+						\WP_CLI::error( "Couldn't uninstall language: $language_code from theme $theme." );
 					}
 				}
 

--- a/src/Theme_Language_Command.php
+++ b/src/Theme_Language_Command.php
@@ -502,7 +502,7 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 
 					if (
 						! in_array( $file, $files_to_remove, true ) &&
-						! preg_match( "$theme-$language_code-\w{32}\.json", $file )
+						! preg_match( "/$theme-$language_code-\w{32}\.json/", $file )
 					) {
 						continue;
 					}

--- a/src/Theme_Language_Command.php
+++ b/src/Theme_Language_Command.php
@@ -492,8 +492,9 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 					"$theme-$language_code.l10n.php",
 				);
 
-				$count_files_removed = 0;
-				$had_one_file        = false;
+				$count_files_to_remove = 0;
+				$count_files_removed   = 0;
+				$had_one_file          = false;
 
 				foreach ( $files as $file ) {
 					if ( '.' === $file[0] || is_dir( $file ) ) {
@@ -509,6 +510,8 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 
 					$had_one_file = true;
 
+					++$count_files_to_remove;
+
 					if ( $wp_filesystem->delete( WP_LANG_DIR . $dir . '/' . $file ) ) {
 						++$count_files_removed;
 					} else {
@@ -516,7 +519,7 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 					}
 				}
 
-				if ( count( $files_to_remove ) === $count_files_removed ) {
+				if ( $count_files_to_remove === $count_files_removed ) {
 					$result['status'] = 'uninstalled';
 					++$successes;
 					\WP_CLI::log( "Language '{$language_code}' for '{$theme}' uninstalled." );

--- a/src/Theme_Language_Command.php
+++ b/src/Theme_Language_Command.php
@@ -512,7 +512,7 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 
 					++$count_files_to_remove;
 
-					if ( $wp_filesystem->delete( WP_LANG_DIR . $dir . '/' . $file ) ) {
+					if ( $wp_filesystem->delete( $dir . '/' . $file ) ) {
 						++$count_files_removed;
 					} else {
 						\WP_CLI::error( "Couldn't uninstall language: $language_code from theme $theme." );


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

JSON translation files were introduced in WordPress 5.0. Testing their removal is trickier as the file names contain MD5 hashes that can change, so I didn't include this.

`.l10n.php` are a new introduction in WordPress 6.5. Language packs served by wp.org will soon start to include those. files.

Fixes #129