### PR TITLE
Improve warning message for unavailable language pack

### DIFF
--- a/features/language-plugin.feature
+++ b/features/language-plugin.feature
@@ -157,7 +157,7 @@ Feature: Manage translation files for a WordPress install
     When I try `wp language plugin install hello-dolly en_GB de_DE invalid_lang`
     Then STDERR should be:
       """
-      Warning: Language 'invalid_lang' not available.
+      Warning: Language 'invalid_lang' for 'hello-dolly' not available.
       """
     And STDOUT should contain:
       """

--- a/features/language-theme.feature
+++ b/features/language-theme.feature
@@ -142,7 +142,7 @@ Feature: Manage translation files for a WordPress install
     When I try `wp language theme install twentyten invalid_lang`
     Then STDERR should be:
       """
-      Warning: Language 'invalid_lang' not available.
+      Warning: Language 'invalid_lang' for 'twentyten' not available.
       """
     And STDOUT should be:
       """

--- a/src/WP_CLI/CommandWithTranslation.php
+++ b/src/WP_CLI/CommandWithTranslation.php
@@ -216,7 +216,7 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 		}
 
 		if ( ! $translation_to_load ) {
-			return new \WP_Error( 'not_found', "Language '{$download}' not available." );
+			return new \WP_Error( 'not_found', $slug ? "Language '{$download}' for '{$slug}' not available." : "Language '{$download}' not available." );
 		}
 		$translation = (object) $translation;
 
@@ -235,7 +235,7 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 		}
 
 		if ( ! $result ) {
-			return new \WP_Error( 'not_installed', "Could not install language '{$download}'." );
+			return new \WP_Error( 'not_installed', $slug ? "Could not install language '{$download}' for '{$slug}'." : "Could not install language '{$download}'." );
 		}
 
 		return $translation->language;


### PR DESCRIPTION
Fixes https://github.com/wp-cli/language-command/issues/138

* For core, message is kept same.
* For plugin and theme, warning message is changed as below:

Before: 
```
Warning: Language 'invalid_lang' not available.
```

After: 
```
Warning: Language 'invalid_lang' for 'hello-dolly' not available.
```