### PR TITLE
Add --format-count in language list commands

### DIFF
--- a/features/language-core.feature
+++ b/features/language-core.feature
@@ -77,6 +77,12 @@ Feature: Manage translation files for a WordPress install
       | ar        | Arabic           | uninstalled   |
       | en_GB     | English (UK)     | installed     |
 
+    When I run `wp language core list --status=installed --format=count`
+    Then STDOUT should be:
+      """
+      4
+      """
+
     When I run `wp site switch-language en_GB`
     Then STDOUT should be:
       """

--- a/features/language-plugin.feature
+++ b/features/language-plugin.feature
@@ -96,6 +96,12 @@ Feature: Manage translation files for a WordPress install
       | en_US     | English (United States) | none     |
       | en_GB     | English (UK)            | none     |
 
+    When I run `wp language plugin list hello-dolly --status=installed --format=count`
+    Then STDOUT should be:
+      """
+      3
+      """
+
     When I run `wp language plugin update --all`
     Then STDOUT should contain:
       """

--- a/features/language-theme.feature
+++ b/features/language-theme.feature
@@ -95,6 +95,12 @@ Feature: Manage translation files for a WordPress install
       | en_GB     | English (UK)            | none     |
       | en_US     | English (United States) | none     |
 
+    When I run `wp language theme list twentyten --status=installed --format=count`
+    Then STDOUT should be:
+      """
+      3
+      """
+
     When I run `wp language theme update --all`
     Then STDOUT should contain:
       """

--- a/src/Core_Language_Command.php
+++ b/src/Core_Language_Command.php
@@ -67,6 +67,7 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 	 *   - table
 	 *   - csv
 	 *   - json
+	 *   - count
 	 * ---
 	 *
 	 * ## AVAILABLE FIELDS

--- a/src/Plugin_Language_Command.php
+++ b/src/Plugin_Language_Command.php
@@ -76,6 +76,7 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 	 *   - table
 	 *   - csv
 	 *   - json
+	 *   - count
 	 * ---
 	 *
 	 * ## AVAILABLE FIELDS

--- a/src/Theme_Language_Command.php
+++ b/src/Theme_Language_Command.php
@@ -76,6 +76,7 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 	 *   - table
 	 *   - csv
 	 *   - json
+	 *   - count
 	 * ---
 	 *
 	 * ## AVAILABLE FIELDS


### PR DESCRIPTION
Fixes https://github.com/wp-cli/language-command/issues/150

* Add `--format=count` for `language core|plugin|theme list` commands