### PR TITLE
Remove default available translation for plugins and themes

### DIFF
--- a/src/WP_CLI/CommandWithTranslation.php
+++ b/src/WP_CLI/CommandWithTranslation.php
@@ -251,7 +251,6 @@ abstract class CommandWithTranslation extends WP_CLI_Command {
 	protected function get_installed_languages( $slug = 'default' ) {
 		$available   = wp_get_installed_translations( $this->obj_type );
 		$available   = ! empty( $available[ $slug ] ) ? array_keys( $available[ $slug ] ) : array();
-		$available[] = 'en_US';
 
 		return $available;
 	}


### PR DESCRIPTION
`en_US` translations may not be always installed in the case of plugins and themes, so I removed the line of code that assumes the availability of the language. Now the available translations are the only ones got from `wp_get_installed_translations`.
This should fix #84

Related https://github.com/wp-cli/wp-cli/issues/5955

