### PR TITLE
Allow filtering languages by multiple statuses

### DIFF
--- a/features/language-core.feature
+++ b/features/language-core.feature
@@ -535,3 +535,15 @@ Feature: Manage translation files for a WordPress install
       """
       en_US
       """
+
+    @require-wp-4.0
+    Scenario: List languages by multiple statuses
+      Given a WP install
+      And an empty cache
+
+      When I run `wp language core install nl_NL`
+      When I run `wp language core list --fields=language,status --status=active,installed`
+      Then STDOUT should be a table containing rows:
+        | language  | status     |
+        | en_US     | active     |
+        | nl_NL     | installed  |

--- a/features/language-core.feature
+++ b/features/language-core.feature
@@ -540,8 +540,8 @@ Feature: Manage translation files for a WordPress install
     Scenario: List languages by multiple statuses
       Given a WP install
       And an empty cache
+      And I run `wp language core install nl_NL`
 
-      When I run `wp language core install nl_NL`
       When I run `wp language core list --fields=language,status --status=active,installed`
       Then STDOUT should be a table containing rows:
         | language  | status     |

--- a/features/language-core.feature
+++ b/features/language-core.feature
@@ -547,3 +547,4 @@ Feature: Manage translation files for a WordPress install
         | language  | status     |
         | en_US     | active     |
         | nl_NL     | installed  |
+      And STDERR should be empty

--- a/features/language-plugin.feature
+++ b/features/language-plugin.feature
@@ -439,3 +439,16 @@ Feature: Manage translation files for a WordPress install
       jetpack,invalid_lang,"not available"
       """
     And STDERR should be empty
+
+  @require-wp-4.0
+  Scenario: List languages by multiple statuses
+    Given a WP install
+    And an empty cache
+    And I run `wp language plugin install akismet nl_NL`
+
+    When I run `wp language plugin list --all --fields=plugin,language,status --status=active,installed`
+    Then STDOUT should be a table containing rows:
+      | plugin   | language | status    |
+      | akismet  | en_US    | active    |
+      | akismet  | nl_NL    | installed |
+    And STDERR should be empty

--- a/features/language-theme.feature
+++ b/features/language-theme.feature
@@ -314,3 +314,17 @@ Feature: Manage translation files for a WordPress install
       twentysixteen,de_DE,"not installed"
       """
     And STDERR should be empty
+
+  @require-wp-4.0
+  Scenario: List languages by multiple statuses
+    Given a WP install
+    And an empty cache
+    And I run `wp theme install twentyten`
+    And I run `wp language theme install twentyten nl_NL`
+
+    When I run `wp language theme list twentyten --fields=language,status --status=active,installed`
+    Then STDOUT should be a table containing rows:
+      | language | status    |
+      | en_US    | active    |
+      | nl_NL    | installed |
+    And STDERR should be empty

--- a/features/language-theme.feature
+++ b/features/language-theme.feature
@@ -319,7 +319,7 @@ Feature: Manage translation files for a WordPress install
   Scenario: List languages by multiple statuses
     Given a WP install
     And an empty cache
-    And I run `wp theme install twentyten`
+    And I run `wp theme install twentyten --force`
     And I run `wp language theme install twentyten nl_NL`
 
     When I run `wp language theme list twentyten --fields=language,status --status=active,installed`

--- a/src/Core_Language_Command.php
+++ b/src/Core_Language_Command.php
@@ -126,7 +126,7 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 
 		foreach ( $translations as $key => $translation ) {
 			foreach ( array_keys( $translation ) as $field ) {
-				if ( isset( $assoc_args[ $field ] ) && $assoc_args[ $field ] !== $translation[ $field ] ) {
+				if ( isset( $assoc_args[ $field ] ) && ! in_array( $translation[ $field ], array_map( 'trim', explode( ',', $assoc_args[ $field ] ) ), true ) ) {
 					unset( $translations[ $key ] );
 				}
 			}

--- a/src/Plugin_Language_Command.php
+++ b/src/Plugin_Language_Command.php
@@ -154,7 +154,7 @@ class Plugin_Language_Command extends WP_CLI\CommandWithTranslation {
 
 				// Support features like --status=active.
 				foreach ( array_keys( $translation ) as $field ) {
-					if ( isset( $assoc_args[ $field ] ) && $assoc_args[ $field ] !== $translation[ $field ] ) {
+					if ( isset( $assoc_args[ $field ] ) && ! in_array( $translation[ $field ], array_map( 'trim', explode( ',', $assoc_args[ $field ] ) ), true ) ) {
 						continue 2;
 					}
 				}

--- a/src/Theme_Language_Command.php
+++ b/src/Theme_Language_Command.php
@@ -160,7 +160,7 @@ class Theme_Language_Command extends WP_CLI\CommandWithTranslation {
 
 				// Support features like --status=active.
 				foreach ( array_keys( $translation ) as $field ) {
-					if ( isset( $assoc_args[ $field ] ) && $assoc_args[ $field ] !== $translation[ $field ] ) {
+					if ( isset( $assoc_args[ $field ] ) && ! in_array( $translation[ $field ], array_map( 'trim', explode( ',', $assoc_args[ $field ] ) ), true ) ) {
 						continue 2;
 					}
 				}


### PR DESCRIPTION
Makes it possible to filter using multiple statuses.

Example: `wp language core list --status=active,installed`

Implementation is based on [this comment and code example](https://github.com/wp-cli/language-command/issues/96#issuecomment-658670667)

Fixes #96 
