### PR TITLE
docs: add --format example to wp language core list

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,10 @@ Downloads the language pack from WordPress.org. Find your language code at: http
 
 
 ### wp language core list
+#### Example with --format flag:
 
+```bash
+$ wp language core list --status=installed --format=json
 Lists all available languages.
 
 ~~~


### PR DESCRIPTION
 =This PR adds a usage example for the `--format=json` flag in the `wp language core list` command.

It helps users understand how to get installed language packs in machine-readable format.

Fixes: https://github.com/wp-cli/language-command/issues/84
