### PR TITLE
Exclude the wp-compat false positive from the PHPStan config

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -18,3 +18,15 @@ parameters:
     switchConditionsMatchingType: true
   ignoreErrors:
     - identifier: missingType.return
+
+    # johnbillion/wp-compat checks every WordPress symbol against the WordPress 4.9
+    # baseline that wp-cli-tests configures, and reports anything newer.
+
+    # WordPress 6.0 only formalized the already documented `...$args` parameter of
+    # `apply_filters()` by adding it to the function signature. Additional arguments were
+    # collected through `func_get_args()` before that, so passing `$package`, `$this` and
+    # `$hook_extra` to `upgrader_pre_download` has always worked. The identifier already
+    # names one specific parameter of one specific function.
+    -
+      identifier: WPCompat.parameterNotAvailable.applyfilters.args
+      path: src/WP_CLI/LanguagePackUpgrader.php


### PR DESCRIPTION
The `johnbillion/wp-compat` PHPStan extension that now ships with `wp-cli-tests` checks every WordPress symbol against the WordPress 4.9 baseline that `wp-cli-tests` configures. It reported exactly one error here, and it is a false positive.

| Where | Reported | Why it is a false positive |
| --- | --- | --- |
| `src/WP_CLI/LanguagePackUpgrader.php:78` | `Parameter $args of apply_filters() is only available since WordPress version 6.0.0` | WordPress 6.0 only "formalized the existing and already documented `...$args` parameter by adding it to the function signature". Before that, `apply_filters()` collected additional arguments through `func_get_args()`, so passing `$package`, `$this` and `$hook_extra` to `upgrader_pre_download` has always worked |

Ignored by error identifier and path. No message scoping was needed: `WPCompat.parameterNotAvailable.applyfilters.args` already names one specific parameter of one specific function, so the entry cannot swallow an unrelated diagnostic.

No source changes: nothing here is an actual compatibility problem.

## Verification

Run locally against the same dependency versions CI resolves (`johnbillion/wp-compat` 2.0.0, `php-stubs/wordpress-stubs` v6.9.4, `wp-cli/wp-cli-tests` v5.2.3):

- `composer phpstan` — `[OK] No errors`, with no unmatched ignore entries
- As a control, adding a deliberately dead ignore entry does produce an `ignore.unmatched` error, confirming the entry above matches a real error rather than sitting there unused

GitHub Actions was failing to allocate runners across the org while this was written, so CI may need a re-run once that clears.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSjnuDoRgWkj4DjRgHbtNB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated static analysis configuration to account for a known WordPress compatibility warning.
  * Added documentation clarifying the supported WordPress version context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->